### PR TITLE
Add New Relic agent as an optional dependency

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,0 +1,2 @@
+# Optional packages
+newrelic==2.54.0.41


### PR DESCRIPTION
@feanil are we pinned to a specific version of the New Relic agent? `2.54.0.41` is the latest version, but ecommerce runs `2.46.0.37`.

FYI @jimabramson @clintonb.
