### PR TITLE
Prevent Celery from removing handlers on the root logger.

### DIFF
--- a/ecommerce_worker/configuration/base.py
+++ b/ecommerce_worker/configuration/base.py
@@ -11,6 +11,10 @@ CELERY_RESULT_BACKEND = None
 CELERY_IMPORTS = (
     'ecommerce_worker.fulfillment.v1.tasks',
 )
+
+# Prevent Celery from removing handlers on the root logger. Allows setting custom logging handlers.
+# See http://celery.readthedocs.org/en/latest/configuration.html#celeryd-hijack-root-logger.
+CELERYD_HIJACK_ROOT_LOGGER = False
 # END CELERY
 
 

--- a/ecommerce_worker/configuration/logger.py
+++ b/ecommerce_worker/configuration/logger.py
@@ -11,7 +11,7 @@ def get_logger_config(log_dir='/var/tmp',
                       dev_env=False,
                       debug=False,
                       local_loglevel='INFO',
-                      service_variant='ecommerce-worker'):
+                      service_variant='ecommerce_worker'):
 
     """
     Returns a dictionary containing logging configuration.


### PR DESCRIPTION
Allows setting custom logging handlers.

FYI @feanil @clintonb @jimabramson 
