### PR TITLE
Enable authentication via JWT for ecommerce workers.

### DIFF
--- a/ecommerce_worker/configuration/__init__.py
+++ b/ecommerce_worker/configuration/__init__.py
@@ -1,0 +1,14 @@
+import os
+
+def get_overrides_filename(variable):
+    """
+    Get the name of the file containing configuration overrides
+    from the provided environment variable.
+    """
+    filename = os.environ.get(variable)
+
+    if filename is None:
+        msg = 'Please set the {} environment variable.'.format(variable)
+        raise EnvironmentError(msg)
+
+    return filename

--- a/ecommerce_worker/configuration/base.py
+++ b/ecommerce_worker/configuration/base.py
@@ -22,12 +22,16 @@ CELERYD_HIJACK_ROOT_LOGGER = False
 # Absolute URL used to construct API calls against the ecommerce service.
 ECOMMERCE_API_ROOT = None
 
-# Long-lived access token used by Celery workers to authenticate against the ecommerce service.
-WORKER_ACCESS_TOKEN = None
-
 # Maximum number of retries before giving up on the fulfillment of an order.
 # For reference, 11 retries with exponential backoff yields a maximum waiting
 # time of 2047 seconds (about 30 minutes). Defaulting this to None could yield
 # unwanted behavior: infinite retries.
 MAX_FULFILLMENT_RETRIES = 11
 # END ORDER FULFILLMENT
+
+# AUTHENTICATION
+JWT_SECRET_KEY = None
+JWT_ISSUER = None
+
+ECOMMERCE_SERVICE_USERNAME = 'ecommerce_worker'
+# END AUTHENTICATION

--- a/ecommerce_worker/configuration/devstack.py
+++ b/ecommerce_worker/configuration/devstack.py
@@ -1,17 +1,19 @@
+import logging
 from logging.config import dictConfig
 
 import yaml
 
-from ecommerce_worker.configuration import get_overrides_filename
+from . import get_overrides_filename
 from ecommerce_worker.configuration.base import *
 from ecommerce_worker.configuration.logger import get_logger_config
 
+logger = logging.getLogger(__name__)
+
 
 # LOGGING
-logger_config = get_logger_config()
+logger_config = get_logger_config(debug=True, dev_env=True, local_loglevel='DEBUG')
 dictConfig(logger_config)
 # END LOGGING
-
 
 filename = get_overrides_filename('ECOMMERCE_WORKER_CFG')
 with open(filename) as f:
@@ -19,3 +21,10 @@ with open(filename) as f:
 
 # Override base configuration with values from disk.
 vars().update(config_from_yaml)
+
+# Apply any developer-defined overrides.
+try:
+    from ecommerce_worker.configuration.private import *  # pylint: disable=import-error
+except ImportError:
+    logger.warning('No developer-defined configuration overrides have been applied.')
+    pass

--- a/ecommerce_worker/configuration/local.py
+++ b/ecommerce_worker/configuration/local.py
@@ -16,16 +16,19 @@ BROKER_URL = 'amqp://'
 ECOMMERCE_API_ROOT = 'http://localhost:8002/api/v2/'
 # END ORDER FULFILLMENT
 
+# AUTHENTICATION
+JWT_SECRET_KEY = 'insecure-secret-key'
+JWT_ISSUER = 'ecommerce_worker'
+# END AUTHENTICATION
 
 # LOGGING
 logger_config = get_logger_config(debug=True, dev_env=True, local_loglevel='DEBUG')
 dictConfig(logger_config)
 # END LOGGING
 
-
 # Apply any developer-defined overrides.
 try:
-    from .private import *  # pylint: disable=import-error
+    from ecommerce_worker.configuration.private import *  # pylint: disable=import-error
 except ImportError:
     logger.warning('No developer-defined configuration overrides have been applied.')
     pass

--- a/ecommerce_worker/configuration/test.py
+++ b/ecommerce_worker/configuration/test.py
@@ -19,3 +19,10 @@ WORKER_ACCESS_TOKEN = 'fake-access-token'
 logger_config = get_logger_config(debug=True, dev_env=True, local_loglevel='DEBUG')
 dictConfig(logger_config)
 # END LOGGING
+
+# AUTHENTICATION
+JWT_SECRET_KEY = 'test-key'
+JWT_ISSUER = 'ecommerce_worker'
+
+ECOMMERCE_SERVICE_USERNAME = 'service'
+# END AUTHENTICATION

--- a/ecommerce_worker/fulfillment/v1/tasks.py
+++ b/ecommerce_worker/fulfillment/v1/tasks.py
@@ -21,14 +21,12 @@ def fulfill_order(self, order_number):
         None
     """
     ecommerce_api_root = get_configuration('ECOMMERCE_API_ROOT')
-    worker_access_token = get_configuration('WORKER_ACCESS_TOKEN')
     max_fulfillment_retries = get_configuration('MAX_FULFILLMENT_RETRIES')
+    signing_key = get_configuration('JWT_SECRET_KEY')
+    issuer = get_configuration('JWT_ISSUER')
+    service_username = get_configuration('ECOMMERCE_SERVICE_USERNAME')
 
-    if not (ecommerce_api_root and worker_access_token and max_fulfillment_retries):
-        raise RuntimeError('Worker is improperly configured for order fulfillment.')
-
-    api = EcommerceApiClient(ecommerce_api_root, oauth_access_token=worker_access_token)
-
+    api = EcommerceApiClient(ecommerce_api_root, signing_key=signing_key, issuer=issuer, username=service_username)
     try:
         logger.info('Requesting fulfillment of order [%s].', order_number)
         api.orders(order_number).fulfill.put()

--- a/ecommerce_worker/utils.py
+++ b/ecommerce_worker/utils.py
@@ -25,4 +25,7 @@ def get_configuration(variable):
     __import__(name)
     module = sys.modules[name]
 
-    return getattr(module, variable, None)
+    value = getattr(module, variable, None)
+    if value is None:
+        raise RuntimeError('Worker is improperly configured: {} is unset in {}.'.format(variable, module))
+    return value

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst') as readme:
 
 setup(
     name='edx-ecommerce-worker',
-    version='0.1.0',
+    version='0.2.0',
     description='Celery tasks supporting the operations of edX\'s ecommerce service',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
The `fulfill_order` task is now passed the information to create a JWT to authenticate to the ecommerce service.

@rlucioni @clintonb @bderusha @rock345 
