### PR TITLE
Avoid initialization of Celery when used as a package

### DIFF
--- a/ecommerce_worker/celery_app.py
+++ b/ecommerce_worker/celery_app.py
@@ -1,13 +1,12 @@
 import os
 from celery import Celery
 
+from ecommerce_worker.configuration import CONFIGURATION_MODULE
 
-# Environment variable indicating which configuration module to use.
-CONFIGURATION = 'WORKER_CONFIGURATION_MODULE'
 
 # Set the default configuration module, if one is not aleady defined.
-os.environ.setdefault(CONFIGURATION, 'ecommerce_worker.configuration.local')
+os.environ.setdefault(CONFIGURATION_MODULE, 'ecommerce_worker.configuration.local')
 
 app = Celery('ecommerce_worker')
 # See http://celery.readthedocs.org/en/latest/userguide/application.html#config-from-envvar.
-app.config_from_envvar(CONFIGURATION)
+app.config_from_envvar(CONFIGURATION_MODULE)

--- a/ecommerce_worker/configuration/__init__.py
+++ b/ecommerce_worker/configuration/__init__.py
@@ -1,5 +1,11 @@
 import os
 
+
+# Environment variable indicating which configuration module to use
+# when running the worker.
+CONFIGURATION_MODULE = 'WORKER_CONFIGURATION_MODULE'
+
+
 def get_overrides_filename(variable):
     """
     Get the name of the file containing configuration overrides

--- a/ecommerce_worker/fulfillment/v1/tests/test_tasks.py
+++ b/ecommerce_worker/fulfillment/v1/tests/test_tasks.py
@@ -9,6 +9,8 @@ import httpretty
 import jwt
 import mock
 
+# Ensures that a Celery app is initialized when tests are run.
+from ecommerce_worker import celery_app  # pylint: disable=unused-import
 from ecommerce_worker.fulfillment.v1.tasks import fulfill_order
 from ecommerce_worker.utils import get_configuration
 

--- a/ecommerce_worker/utils.py
+++ b/ecommerce_worker/utils.py
@@ -2,7 +2,7 @@
 import os
 import sys
 
-from ecommerce_worker.celery_app import CONFIGURATION
+from ecommerce_worker.configuration import CONFIGURATION_MODULE
 
 
 def get_configuration(variable):
@@ -17,7 +17,7 @@ def get_configuration(variable):
     Returns:
         The value corresponding to the variable, or None if the variable is not found.
     """
-    name = os.environ.get(CONFIGURATION)
+    name = os.environ.get(CONFIGURATION_MODULE)
 
     # __import__ performs a full import, but only returns the top-level
     # package, not the targeted module. sys.modules is a dictionary

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst') as readme:
 
 setup(
     name='edx-ecommerce-worker',
-    version='0.2.0',
+    version='0.3.0',
     description='Celery tasks supporting the operations of edX\'s ecommerce service',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
Previously, a cascade of imports caused a Celery app to be initialized whenever a shared task was imported. This is undesired: the application calling the shared task should be allowed to initialize and use its own Celery app. ECOM-2249.

@jimabramson please review.
