### PR TITLE
Fix service_variant label used for logging

### DIFF
--- a/ecommerce_worker/configuration/logger.py
+++ b/ecommerce_worker/configuration/logger.py
@@ -11,7 +11,7 @@ def get_logger_config(log_dir='/var/tmp',
                       dev_env=False,
                       debug=False,
                       local_loglevel='INFO',
-                      service_variant='ecommerce_worker'):
+                      service_variant='ecomworker'):
 
     """
     Returns a dictionary containing logging configuration.


### PR DESCRIPTION
We use an rsyslog DynaFile template to look for the service_variant label in log messages and dump them to `/edx/var/log/<service_variant>/edx.log`. Since the service_variant used here was the old 'ecommerce_worker', logs were being dumped to the wrong location on disk. This is half of a larger problem with ecomworker logging, the other half being forwarding the correct logs Splunk. ECOM-3496.

@jibsheet @jimabramson 
