### PR TITLE
Removed SAILTHRU_MINIMUM_COST

### DIFF
--- a/ecommerce_worker/configuration/base.py
+++ b/ecommerce_worker/configuration/base.py
@@ -84,10 +84,6 @@ SAILTHRU = {
     # ttl for cached course content from Sailthru (in seconds)
     'SAILTHRU_CACHE_TTL_SECONDS': 3600,
 
-    # dummy price for audit/honor (i.e., if cost = 0)
-    #  Note: setting this value to 0 skips Sailthru calls for free transactions
-    'SAILTHRU_MINIMUM_COST': 100,
-
     # Transactional email template name map
     'templates': {
         'course_refund': 'Course Refund',

--- a/ecommerce_worker/sailthru/v1/tasks.py
+++ b/ecommerce_worker/sailthru/v1/tasks.py
@@ -276,11 +276,6 @@ def update_course_enrollment(self, email, course_url, purchase_incomplete, mode,
     # calc price in pennies for Sailthru
     #  https://getstarted.sailthru.com/new-for-developers-overview/advanced-features/purchase/
     cost_in_cents = int(unit_cost * 100)
-    if not cost_in_cents:
-        cost_in_cents = config.get('SAILTHRU_MINIMUM_COST')
-        # if still zero, ignore purchase since Sailthru can't deal with $0 transactions
-        if not cost_in_cents:
-            return
 
     # update the "unenrolled" course array in the user record on Sailthru if new enroll or unenroll
     if new_enroll:


### PR DESCRIPTION
Sailthru now supports $0 purchases. SAILTHRU_MINIMUM_COST has been removed as it is no longer needed.

LEARNER-1519