### PR TITLE
fixed bug

### DIFF
--- a/ecommerce_worker/fulfillment/v1/tasks.py
+++ b/ecommerce_worker/fulfillment/v1/tasks.py
@@ -1,4 +1,6 @@
 """Order fulfillment tasks."""
+from ssl import SSLError
+
 from celery import shared_task
 from celery.exceptions import Ignore
 from celery.utils.log import get_task_logger
@@ -55,6 +57,6 @@ def fulfill_order(self, order_number, site_code=None, email_opt_in=False):
             )
             _retry_order(self, exc, max_fulfillment_retries, order_number)
 
-    except (exceptions.HttpServerError, exceptions.Timeout) as exc:
+    except (exceptions.HttpServerError, exceptions.Timeout, SSLError) as exc:
         # Fulfillment failed, retry
         _retry_order(self, exc, max_fulfillment_retries, order_number)


### PR DESCRIPTION
Some times fulfillment task fails with ssl error we need to handle the exception to keep trying. 


Nov 2 16:37:20 ip-10-2-110-214 [service_variant=ecomworker][celery.worker.job][env:no_env] ERROR [ip-10-2-110-214 1680] [log.py:282] - Task ecommerce_worker.fulfillment.v1.tasks.fulfill_order[a02db1ab-3fca-4301-89ed-2f0468de2d93] raised unexpected: SSLError(SSLError(SSLError(1, u'[SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] sslv3 alert handshake failure (_ssl.c:590)'),),)
Traceback (most recent call last):
File "/edx/app/ecomworker/venvs/ecomworker/local/lib/python2.7/site-packages/celery/app/trace.py", line 240, in trace_task
R = retval = fun(*args, **kwargs)
File "/edx/app/ecomworker/venvs/ecomworker/local/lib/python2.7/site-packages/newrelic/hooks/application_celery.py", line 84, in wrapper
return wrapped(*args, **kwargs)
File "/edx/app/ecomworker/venvs/ecomworker/local/lib/python2.7/site-packages/celery/app/trace.py", line 438, in __protected_call__
return self.run(*args, **kwargs)
File "/edx/app/ecomworker/ecomworker/ecommerce_worker/fulfillment/v1/tasks.py", line 42, in fulfill_order
api.orders(order_number).fulfill.put(email_opt_in=email_opt_in)
File "/edx/app/ecomworker/venvs/ecomworker/local/lib/python2.7/site-packages/slumber/__init__.py", line 175, in put
resp = self._request("PUT", data=data, files=files, params=kwargs)
File "/edx/app/ecomworker/venvs/ecomworker/local/lib/python2.7/site-packages/slumber/__init__.py", line 97, in _request
resp = self._store["session"].request(method, url, data=data, params=params, files=files, headers=headers)
File "/edx/app/ecomworker/venvs/ecomworker/local/lib/python2.7/site-packages/requests/sessions.py", line 488, in request
resp = self.send(prep, **send_kwargs)
File "/edx/app/ecomworker/venvs/ecomworker/local/lib/python2.7/site-packages/newrelic/api/external_trace.py", line 121, in dynamic_wrapper
return wrapped(*args, **kwargs)
File "/edx/app/ecomworker/venvs/ecomworker/local/lib/python2.7/site-packages/requests/sessions.py", line 609, in send
r = adapter.send(request, **kwargs)
File "/edx/app/ecomworker/venvs/ecomworker/local/lib/python2.7/site-packages/requests/adapters.py", line 497, in send
raise SSLError(e, request=request)
SSLError: [SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] sslv3 alert handshake failure (_ssl.c:590)