### PR TITLE
ENT-1362: Updated ecommerce assignment-email api call parameters

### DIFF
--- a/ecommerce_worker/sailthru/v1/tests/test_tasks.py
+++ b/ecommerce_worker/sailthru/v1/tests/test_tasks.py
@@ -657,7 +657,7 @@ class SendOfferAssignmentEmailTests(TestCase):
     """ Validates the send_offer_assignment_email task. """
     LOG_NAME = 'ecommerce_worker.sailthru.v1.tasks'
     USER_EMAIL = 'user@unknown.com'
-    OFFER_ID = '555'
+    OFFER_ASSIGNMENT_ID = '555'
     SEND_ID = '1234ABC'
     SUBJECT = 'New edX course assignment'
     EMAIL_BODY = 'Template message with johndoe@unknown.com GIL7RUEOU7VHBH7Q ' \
@@ -665,7 +665,7 @@ class SendOfferAssignmentEmailTests(TestCase):
 
     def execute_task(self):
         """ Execute the send_offer_assignment_email task. """
-        send_offer_assignment_email(self.USER_EMAIL, self.OFFER_ID, self.SUBJECT, self.EMAIL_BODY, None)
+        send_offer_assignment_email(self.USER_EMAIL, self.OFFER_ASSIGNMENT_ID, self.SUBJECT, self.EMAIL_BODY, None)
 
     def mock_api_response(self, status, body):
         """ Mock the Sailthru send API. """
@@ -681,7 +681,7 @@ class SendOfferAssignmentEmailTests(TestCase):
         """ Mock POST requests to the ecommerce assignmentemail API endpoint. """
         httpretty.reset()
         httpretty.register_uri(
-            httpretty.POST, '{}/assignmentemail/updatestatus/'.format(
+            httpretty.POST, '{}/assignment-email/status/'.format(
                 get_configuration('ECOMMERCE_API_ROOT').strip('/')
             ),
             status=status,
@@ -786,11 +786,11 @@ class SendOfferAssignmentEmailTests(TestCase):
         log.check(
             (self.LOG_NAME, 'ERROR', '[Offer Assignment] An error occurred while updating offer assignment email status'
              ' for offer id {token_offer} and message id {token_send_id} via the Ecommerce API.'.format(
-                 token_offer=self.OFFER_ID,
+                 token_offer=self.OFFER_ASSIGNMENT_ID,
                  token_send_id=self.SEND_ID)),
             (self.LOG_NAME, 'ERROR', '[Offer Assignment] An error occurred while updating email status data for '
              'offer {token_offer} and email {token_email} via the ecommerce API.'.format(
-                 token_offer=self.OFFER_ID,
+                 token_offer=self.OFFER_ASSIGNMENT_ID,
                  token_email=self.USER_EMAIL,))
         )
 
@@ -799,7 +799,7 @@ class SendOfferAssignmentEmailTests(TestCase):
         (
             # Success case
             {
-                'offer_id': '555',
+                'offer_assignment_id': '555',
                 'send_id': '1234ABC',
                 'status': 'updated',
                 'error': ''
@@ -809,7 +809,7 @@ class SendOfferAssignmentEmailTests(TestCase):
         (
             # Exception case
             {
-                'offer_id': '555',
+                'offer_assignment_id': '555',
                 'send_id': '1234ABC',
                 'status': 'failed',
                 'error': ''

--- a/ecommerce_worker/utils.py
+++ b/ecommerce_worker/utils.py
@@ -46,9 +46,12 @@ def get_configuration(variable, site_code=None):
     return setting_value
 
 
-def get_ecommerce_client(site_code=None):
+def get_ecommerce_client(url_postfix='', site_code=None):
     """
-    Get client for fetching data from ecommerce API
+    Get client for fetching data from ecommerce API.
+    Arguments:
+        site_code (str): (Optional) The SITE_OVERRIDES key to inspect for site-specific values
+        url_postfix (str): (Optional) The URL postfix value to append to the ECOMMERCE_API_ROOT value.
 
     Returns:
         EdxRestApiClient object
@@ -57,4 +60,5 @@ def get_ecommerce_client(site_code=None):
     signing_key = get_configuration('JWT_SECRET_KEY', site_code=site_code)
     issuer = get_configuration('JWT_ISSUER', site_code=site_code)
     service_username = get_configuration('ECOMMERCE_SERVICE_USERNAME', site_code=site_code)
-    return EdxRestApiClient(ecommerce_api_root, signing_key=signing_key, issuer=issuer, username=service_username)
+    return EdxRestApiClient(
+        ecommerce_api_root + url_postfix, signing_key=signing_key, issuer=issuer, username=service_username)


### PR DESCRIPTION
Description: This PR updates the POST parameters for the offer assignment api call in ecommerce (/api/v2/assignment-email/status)

The new request/response format is as follows:
```
POST ecommerce/api/v2/assignment-email/status
```
Request
```
{
    'offer_assignment_id': 1,
    'send_id': 'XBEn85WnoQJsIhk7',
    'status': 'success',
},
```
Response
```
{
    'offer_assignment_id': 1,
    'send_id': 'XBEn85WnoQJsIhk7',
    'status': 'updated',
    'error': ''
},
```