### PR TITLE
Trigger travis on tags as well as master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ sudo: required
 branches:
   only:
     - master
+    - /^\d+\.\d+(\.\d+)?(-\S*)?$/
 
 services:
     - docker


### PR DESCRIPTION
Copying what Jeremy did here (except this repo doesnt use v in the tag name): https://github.com/edx/edx-custom-a11y-rules/pull/12

We need travis to get triggered by tag pushes in order for deploys to pypi to actually work.