### PR TITLE
Define unicode in Python 3

### DIFF
--- a/ecommerce_worker/sailthru/v1/tasks.py
+++ b/ecommerce_worker/sailthru/v1/tasks.py
@@ -11,14 +11,10 @@ from ecommerce_worker.sailthru.v1.exceptions import SailthruError
 from ecommerce_worker.sailthru.v1.utils import get_sailthru_client, get_sailthru_configuration
 from ecommerce_worker.utils import get_ecommerce_client
 from requests.exceptions import RequestException
+from six import text_type
 
 logger = get_task_logger(__name__)  # pylint: disable=invalid-name
 cache = Cache()  # pylint: disable=invalid-name
-
-try:
-    unicode        # Python 2
-except NameError:  # Python 3
-    unicode = str  # pylint: disable=invalid-name,redefined-builtin
 
 
 # pylint: disable=unused-argument
@@ -83,7 +79,7 @@ def _record_purchase(sailthru_client, email, item, purchase_incomplete, message_
             return not can_retry_sailthru_request(error)
 
     except SailthruClientError as exc:
-        logger.exception("Exception attempting to record purchase for %s in Sailthru - %s", email, unicode(exc))
+        logger.exception("Exception attempting to record purchase for %s in Sailthru - %s", email, text_type(exc))
         return False
 
     return True
@@ -210,7 +206,7 @@ def _update_unenrolled_list(sailthru_client, email, course_url, unenroll):
         return True
 
     except SailthruClientError as exc:
-        logger.exception("Exception attempting to update user record for %s in Sailthru - %s", email, unicode(exc))
+        logger.exception("Exception attempting to update user record for %s in Sailthru - %s", email, text_type(exc))
         return False
 
 

--- a/ecommerce_worker/sailthru/v1/tasks.py
+++ b/ecommerce_worker/sailthru/v1/tasks.py
@@ -15,6 +15,11 @@ from requests.exceptions import RequestException
 logger = get_task_logger(__name__)  # pylint: disable=invalid-name
 cache = Cache()  # pylint: disable=invalid-name
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
+
 
 # pylint: disable=unused-argument
 

--- a/ecommerce_worker/sailthru/v1/tasks.py
+++ b/ecommerce_worker/sailthru/v1/tasks.py
@@ -17,8 +17,8 @@ cache = Cache()  # pylint: disable=invalid-name
 
 try:
     unicode        # Python 2
-except NameError:
-    unicode = str  # Python 3
+except NameError:  # Python 3
+    unicode = str  # pylint: disable=invalid-name,redefined-builtin
 
 
 # pylint: disable=unused-argument

--- a/ecommerce_worker/sailthru/v1/tests/test_tasks.py
+++ b/ecommerce_worker/sailthru/v1/tests/test_tasks.py
@@ -19,6 +19,11 @@ from ecommerce_worker.sailthru.v1.tasks import (
 )
 from ecommerce_worker.utils import get_configuration
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
+
 TEST_EMAIL = "test@edx.org"
 
 

--- a/ecommerce_worker/sailthru/v1/tests/test_tasks.py
+++ b/ecommerce_worker/sailthru/v1/tests/test_tasks.py
@@ -21,8 +21,8 @@ from ecommerce_worker.utils import get_configuration
 
 try:
     unicode        # Python 2
-except NameError:
-    unicode = str  # Python 3
+except NameError:  # Python 3
+    unicode = str  # pylint: disable=invalid-name,redefined-builtin
 
 TEST_EMAIL = "test@edx.org"
 

--- a/ecommerce_worker/sailthru/v1/tests/test_tasks.py
+++ b/ecommerce_worker/sailthru/v1/tests/test_tasks.py
@@ -12,17 +12,13 @@ from sailthru import SailthruClient
 from sailthru.sailthru_error import SailthruClientError
 from testfixtures import LogCapture
 from requests.exceptions import RequestException
+from six import text_type
 from ecommerce_worker.sailthru.v1.exceptions import SailthruError
 from ecommerce_worker.sailthru.v1.tasks import (
     update_course_enrollment, _update_unenrolled_list, _get_course_content, _get_course_content_from_ecommerce,
     send_course_refund_email, send_offer_assignment_email, send_offer_update_email, _update_assignment_email_status
 )
 from ecommerce_worker.utils import get_configuration
-
-try:
-    unicode        # Python 2
-except NameError:  # Python 3
-    unicode = str  # pylint: disable=invalid-name,redefined-builtin
 
 TEST_EMAIL = "test@edx.org"
 
@@ -89,7 +85,7 @@ class SailthruTests(TestCase):
         httpretty.reset()
         httpretty.register_uri(
             httpretty.GET, '{}/courses/{}/'.format(
-                get_configuration('ECOMMERCE_API_ROOT').strip('/'), unicode(course_id)
+                get_configuration('ECOMMERCE_API_ROOT').strip('/'), text_type(course_id)
             ),
             status=status,
             body=json.dumps(body), content_type='application/json',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,3 +4,4 @@ celery==3.1.18
 redis==2.10.6
 edx-rest-api-client==1.5.0
 sailthru-client==2.2.3
+six==1.12.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,3 +2,4 @@
 -r base.txt
 
 PyYAML==3.11
+six==1.25.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,4 +2,4 @@
 -r base.txt
 
 PyYAML==3.11
-six==1.25.0
+six==1.12.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,4 +2,3 @@
 -r base.txt
 
 PyYAML==3.11
-six==1.12.0


### PR DESCRIPTION
__unicode__ was removed in Python 3 because all __str__ are Unicode utf-8.

[flake8](http://flake8.pycqa.org) testing of https://github.com/edx/ecommerce-worker on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./ecommerce_worker/sailthru/v1/tasks.py:81:100: F821 undefined name 'unicode'
        logger.exception("Exception attempting to record purchase for %s in Sailthru - %s", email, unicode(exc))
                                                                                                   ^
./ecommerce_worker/sailthru/v1/tasks.py:208:103: F821 undefined name 'unicode'
        logger.exception("Exception attempting to update user record for %s in Sailthru - %s", email, unicode(exc))
                                                                                                      ^
./ecommerce_worker/sailthru/v1/tests/test_tasks.py:87:69: F821 undefined name 'unicode'
                get_configuration('ECOMMERCE_API_ROOT').strip('/'), unicode(course_id)
                                                                    ^
3     F821 undefined name 'unicode'
3
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
