### PR TITLE
[BD-6] Switch to python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: python
-python:
-    - '2.7'
 sudo: required
 
 branches:
@@ -14,12 +12,29 @@ services:
 before_install:
     - docker-compose -f .travis/docker-compose-travis.yml up -d
 
-script:
-    - docker exec ecomworker /edx/app/ecomworker/ecomworker/.travis/run_tests.sh
+install:
+    - docker exec ecomworker bash -c " 
+      sudo apt update -y;
+      sudo apt install python3-dev -y;
+       "
 
-after_success:
-    - pip install -U codecov
-    - codecov
+
+script:
+    - docker exec ecomworker bash -c " 
+      cd /edx/app/ecomworker/ecomworker
+       && make $TARGETS "
+
+matrix:
+  include:
+    - python: 2.7
+      envs: TARGETS="quality"
+    - python: 2.7
+      env: TARGETS="test"
+      after_success:
+        - pip install -U codecov
+        - codecov
+    - python: 3.5
+      env: TARGETS="PYTHON_ENV=py35 test"
 
 deploy:
   provider: pypi
@@ -27,5 +42,7 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
+    python: 2.7
+    condition: "$TARGETS=quality"
   password:
     secure: iYAqXv3vygmnv0ns8jQv0ECclJ1NWj1mjlVYNJsTaEnGmdPifUodr7hTyh/vftYRUtQi1CCWJXF8BEcGuYhahhyWrhkW6R/awArnDooF3gcVzZ9Yn8Zt7zXXRZpgbzXX+1HRUr6WeYoO5S+mXKknORD6bClLYwxKP7sJ1XESmq6Q+WNexb1g3F+AHUXihTJmpGptvZ6rRXIQc+NeozooDKLAgLnyOISGhTyXO3f9DJ8KJmj9QstTDyDutcYsDUN0c6stXk7w0Xr5ErobGXsgUKyadIQ44OgwCsyojh8b454rQOc9C2R1FAaoUAdCsJMJ0ZX1u4d6Tn3/lh2BMWdbLia02mRkW8Y13dg0MvObHOClwG+ElN7/9oW6oK3dHXO1Qstd+z5P/i8rufXlB0fqgmfL5aYz5G2kcUVTg0nyV0Cpn0zelLyCQ2rKpbpMoZJEQGBDBc8MR8uP05pH48TXfqRVOK9x8luKX5PSDXME2u6TLAgBo1Kzcbotlj+YDKtBi6F4Vcl1BsYI4lTM+XelL30xcsmZLi66sxAvpaxAhzpqRrw+4qurUkw9Qd5QDZaP0nwM7V0Cg8MZmRpOSZf4bMB65ba0zmg/DfODoE/e/VXfkonKANbOWFYX5twAX7rsd0Hnyf5YuYF68B3V0OCx/lQCQIwJPRYk3FkPCyMubdM=

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -xe
-. /edx/app/ecomworker/venvs/ecomworker/bin/activate
-
-cd /edx/app/ecomworker/ecomworker
-
-make requirements
-
-# Run validation
-make validate

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PACKAGE = ecommerce_worker
 ROOT = $(shell echo "$$PWD")
-PYTHON_VERSION = py27
+PYTHON_ENV = py27
 
 help:
 	@echo '                                                                                             '
@@ -27,7 +27,7 @@ worker:
 	celery -A ecommerce_worker worker --app=$(PACKAGE).celery_app:app --loglevel=info --queue=fulfillment,email_marketing
 
 test: requirements_tox
-	tox -e ${PYTHON_VERSION}
+	tox -e ${PYTHON_ENV}
 
 quality: requirements_tox
 	tox -e quality
@@ -49,6 +49,9 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip-compile --rebuild --upgrade -o requirements/optional.txt requirements/optional.in
 	pip-compile --rebuild --upgrade -o requirements/local.txt requirements/local.in
 	pip-compile --rebuild --upgrade -o requirements/production.txt requirements/production.in
-
+	# Let tox control the Django version for tests
+	grep -e "^django==" -e "^edx-rest-api-client==" requirements/base.txt > requirements/django.txt
+	sed '/^[dD]jango==/d;/^edx-rest-api-client==/d' requirements/test.txt > requirements/test.tmp
+	mv requirements/test.tmp requirements/test.txt
 
 .PHONY: help requirements worker test html_coverage quality validate clean

--- a/ecommerce_worker/fulfillment/v1/tests/test_tasks.py
+++ b/ecommerce_worker/fulfillment/v1/tests/test_tasks.py
@@ -1,12 +1,13 @@
 """Tests of fulfillment tasks."""
 # pylint: disable=no-value-for-parameter
 from __future__ import absolute_import
+
 from unittest import TestCase
 
 from celery.exceptions import Ignore
 import ddt
 from edx_rest_api_client import exceptions
-import httpretty
+import responses
 import jwt
 import mock
 
@@ -38,73 +39,77 @@ class OrderFulfillmentTaskTests(TestCase):
             with self.assertRaises(RuntimeError):
                 fulfill_order(self.ORDER_NUMBER)
 
-    @httpretty.activate
+    @responses.activate
     def test_fulfillment_success(self):
         """Verify that the task exits without an error when fulfillment succeeds."""
-        httpretty.register_uri(httpretty.PUT, self.API_URL, status=200, body={})
+        responses.add(responses.PUT, self.API_URL, status=200, body="{}")
 
         result = fulfill_order.delay(self.ORDER_NUMBER).get()
         self.assertIsNone(result)
 
         # Validate the value of the HTTP Authorization header.
-        last_request = httpretty.last_request()
+        last_request = responses.calls[-1].request
         token = last_request.headers.get('authorization').split()[1]
         payload = jwt.decode(token, get_configuration('JWT_SECRET_KEY'))
         self.assertEqual(payload['username'], get_configuration('ECOMMERCE_SERVICE_USERNAME'))
 
-    @httpretty.activate
+    @responses.activate
     def test_fulfillment_not_possible(self):
         """Verify that the task exits without an error when fulfillment is not possible."""
-        httpretty.register_uri(httpretty.PUT, self.API_URL, status=406, body={})
+        responses.add(responses.PUT, self.API_URL, status=406, body="{}")
 
         with self.assertRaises(Ignore):
             fulfill_order(self.ORDER_NUMBER)
 
-    @httpretty.activate
+    @responses.activate
     def test_fulfillment_unknown_client_error(self):
         """
         Verify that the task raises an exception when fulfillment fails because of an
         unknown client error.
         """
-        httpretty.register_uri(httpretty.PUT, self.API_URL, status=404, body={})
+        responses.add(responses.PUT, self.API_URL, status=404, body="{}")
 
         with self.assertRaises(exceptions.HttpClientError):
             fulfill_order(self.ORDER_NUMBER)
 
-    @httpretty.activate
+    @responses.activate
     def test_fulfillment_unknown_client_error_retry_success(self):
         """Verify that the task is capable of successfully retrying after client error."""
-        httpretty.register_uri(httpretty.PUT, self.API_URL, responses=[
-            httpretty.Response(status=404, body={}),
-            httpretty.Response(status=200, body={}),
-        ])
+        responses.add(
+            responses.Response(responses.PUT, self.API_URL, status=404, body="{}"),
+        )
+        responses.add(
+            responses.Response(responses.PUT, self.API_URL, status=200, body="{}"),
+        )
 
         result = fulfill_order.delay(self.ORDER_NUMBER).get()
         self.assertIsNone(result)
 
-    @httpretty.activate
+    @responses.activate
     def test_fulfillment_failure(self):
         """Verify that the task raises an exception when fulfillment fails."""
-        httpretty.register_uri(httpretty.PUT, self.API_URL, status=500, body={})
+        responses.add(responses.PUT, self.API_URL, status=500, body="{}")
 
         with self.assertRaises(exceptions.HttpServerError):
             fulfill_order.delay(self.ORDER_NUMBER).get()
 
-    @httpretty.activate
+    @responses.activate
     def test_fulfillment_timeout(self):
         """Verify that the task raises an exception when fulfillment times out."""
-        httpretty.register_uri(httpretty.PUT, self.API_URL, status=404, body=self._timeout_body)
+        responses.add(responses.PUT, self.API_URL, status=404, body=exceptions.Timeout())
 
         with self.assertRaises(exceptions.Timeout):
             fulfill_order.delay(self.ORDER_NUMBER).get()
 
-    @httpretty.activate
+    @responses.activate
     def test_fulfillment_retry_success(self):
         """Verify that the task is capable of successfully retrying after fulfillment failure."""
-        httpretty.register_uri(httpretty.PUT, self.API_URL, responses=[
-            httpretty.Response(status=500, body={}),
-            httpretty.Response(status=200, body={}),
-        ])
+        responses.add(
+            responses.Response(responses.PUT, self.API_URL, status=500, body="{}"),
+        )
+        responses.add(
+            responses.Response(responses.PUT, self.API_URL, status=200, body="{}"),
+        )
 
         result = fulfill_order.delay(self.ORDER_NUMBER).get()
         self.assertIsNone(result)
@@ -114,22 +119,14 @@ class OrderFulfillmentTaskTests(TestCase):
         [False, 'False']
     )
     @ddt.unpack
-    @httpretty.activate
+    @responses.activate
     def test_email_opt_in_parameter_sent(self, email_opt_in_bool, email_opt_in_str):
         """Verify that the task correctly adds the email_opt_in parameter to the request."""
         email_opt_in_api_url = self.API_URL + '?email_opt_in=' + email_opt_in_str
-        httpretty.register_uri(httpretty.PUT, email_opt_in_api_url, status=200, body={})
+        responses.add(responses.PUT, email_opt_in_api_url, status=200, body="{}")
 
         result = fulfill_order.delay(self.ORDER_NUMBER, email_opt_in=email_opt_in_bool).get()
         self.assertIsNone(result)
 
-        last_request = httpretty.last_request()
-        self.assertIn('?email_opt_in=' + email_opt_in_str, last_request.path)
-        # QueryDicts store their values as lists in case multiple values are passed in.
-        # last_request.querystring is returned as a dict instead of a QueryDict
-        # so we have the grab the first element in the list to actually get the value.
-        self.assertEqual(last_request.querystring['email_opt_in'][0], email_opt_in_str)
-
-    def _timeout_body(self, request, uri, headers):  # pylint: disable=unused-argument
-        """Helper used to force httpretty to raise Timeout exceptions."""
-        raise exceptions.Timeout
+        last_request = responses.calls[-1].request
+        self.assertIn('?email_opt_in=' + email_opt_in_str, last_request.path_url)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,9 +10,14 @@ billiard==3.3.0.23        # via celery
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.in
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/base.in
+django-waffle==0.18.0     # via -c requirements/constraints.txt, edx-django-utils
+django==1.11.29           # via edx-django-utils
+edx-django-utils==2.0.4   # via -c requirements/constraints.txt, edx-rest-api-client
+edx-rest-api-client==3.0.2  # via -c requirements/constraints.txt, -r requirements/base.in
 idna==2.9                 # via requests
 kombu==3.0.37             # via celery
+newrelic==5.12.1.141      # via edx-django-utils
+psutil==1.2.1             # via edx-django-utils
 pyjwt==1.7.1              # via edx-rest-api-client
 pytz==2020.1              # via celery
 redis==3.5.2              # via -r requirements/app.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,10 +13,15 @@ futures; python_version == "2.7"
 
 ## Versions used before this accomplished oep-18
 celery>=3.1.18,<4.0.0
-edx-rest-api-client>=1.5.0,<2.0.0
+
+# django-waffle version 0.19.0 dropped support for Django2.0
+django-waffle<0.19.0
+
+# edx-rest-api-client version 4.0.0 dropped support to python 2.7
+edx-rest-api-client<4.0.0
+
+# version 3.0.0 dropped python 2.7 support
+edx-django-utils<3.0.0
 
 # mock version 4.0.0 dropped support for python 2.7 and 3.5
 mock<4.0.0
-
-# https://github.com/gabrielfalcao/HTTPretty/pull/202 breaks the tests
-httpretty==0.8.10

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,0 +1,2 @@
+django==1.11.29           # via edx-django-utils
+edx-rest-api-client==3.0.2  # via -c requirements/constraints.txt, -r requirements/base.in

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -18,25 +18,30 @@ click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, edx-lint
 configparser==4.0.2       # via -r requirements/test.txt, importlib-metadata, pylint
 contextlib2==0.6.0.post1  # via -r requirements/test.txt, importlib-metadata, zipp
+cookies==2.2.1            # via -r requirements/test.txt, responses
 coverage==5.1             # via -r requirements/test.txt, pytest-cov
 ddt==1.4.1                # via -r requirements/test.txt
+django-waffle==0.18.0     # via -c requirements/constraints.txt, -r requirements/test.txt, edx-django-utils
+django==1.11.29           # via -r requirements/test.txt, edx-django-utils
+edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/test.txt, edx-rest-api-client
 edx-lint==1.4.1           # via -r requirements/test.txt
-edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/test.txt
+edx-rest-api-client==3.0.2  # via -c requirements/constraints.txt, -r requirements/test.txt
 enum34==1.1.10            # via -r requirements/test.txt, astroid, ddt
 funcsigs==1.0.2           # via -r requirements/test.txt, mock, pytest
 futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/test.txt, isort
-httpretty==0.8.10         # via -c requirements/constraints.txt, -r requirements/test.txt
 idna==2.9                 # via -r requirements/test.txt, requests
 importlib-metadata==1.6.0  # via -r requirements/test.txt, pluggy, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
 kombu==3.0.37             # via -r requirements/test.txt, celery
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
-mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
+mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt, responses
 more-itertools==5.0.0     # via -r requirements/test.txt, pytest
+newrelic==5.12.1.141      # via -r requirements/test.txt, edx-django-utils
 packaging==20.4           # via -r requirements/test.txt, pytest
 pathlib2==2.3.5           # via -r requirements/test.txt, importlib-metadata, pytest
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
+psutil==1.2.1             # via -r requirements/test.txt, edx-django-utils
 py==1.8.1                 # via -r requirements/test.txt, pytest
 pycodestyle==2.6.0        # via -r requirements/test.txt
 pyjwt==1.7.1              # via -r requirements/test.txt, edx-rest-api-client
@@ -47,14 +52,15 @@ pylint==1.9.5             # via -r requirements/test.txt, edx-lint, pylint-celer
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest==4.6.10            # via -r requirements/test.txt, pytest-cov
-pytz==2020.1              # via -r requirements/test.txt, celery
+pytz==2020.1              # via -r requirements/test.txt, celery, django
 redis==3.5.2              # via -r requirements/test.txt
-requests==2.23.0          # via -r requirements/test.txt, edx-rest-api-client, sailthru-client, slumber
+requests==2.23.0          # via -r requirements/test.txt, edx-rest-api-client, responses, sailthru-client, slumber
+responses==0.10.14        # via -r requirements/test.txt
 sailthru-client==2.3.5    # via -r requirements/test.txt
 scandir==1.10.0           # via -r requirements/test.txt, pathlib2
 simplejson==3.17.0        # via -r requirements/test.txt, sailthru-client
 singledispatch==3.4.0.3   # via -r requirements/test.txt, astroid, pylint
-six==1.14.0               # via -r requirements/test.txt, astroid, edx-lint, mock, more-itertools, packaging, pathlib2, pylint, pytest, singledispatch
+six==1.14.0               # via -r requirements/test.txt, astroid, edx-lint, mock, more-itertools, packaging, pathlib2, pylint, pytest, responses, singledispatch
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 testfixtures==6.14.1      # via -r requirements/test.txt
 urllib3==1.25.9           # via -r requirements/test.txt, requests

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,11 +10,16 @@ billiard==3.3.0.23        # via -r requirements/base.txt, celery
 celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.txt
 certifi==2020.4.5.1       # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
-edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/base.txt
+django-waffle==0.18.0     # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-utils
+django==1.11.29           # via -r requirements/base.txt, edx-django-utils
+edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-rest-api-client
+edx-rest-api-client==3.0.2  # via -c requirements/constraints.txt, -r requirements/base.txt
 idna==2.9                 # via -r requirements/base.txt, requests
 kombu==3.0.37             # via -r requirements/base.txt, celery
+newrelic==5.12.1.141      # via -r requirements/base.txt, edx-django-utils
+psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
 pyjwt==1.7.1              # via -r requirements/base.txt, edx-rest-api-client
-pytz==2020.1              # via -r requirements/base.txt, celery
+pytz==2020.1              # via -r requirements/base.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/production.in
 redis==3.5.2              # via -r requirements/base.txt
 requests==2.23.0          # via -r requirements/base.txt, edx-rest-api-client, sailthru-client, slumber

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -5,7 +5,7 @@
 coverage
 ddt
 edx-lint
-httpretty
+responses
 mock
 pytest
 pytest-cov

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,25 +18,28 @@ click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 configparser==4.0.2       # via importlib-metadata, pylint
 contextlib2==0.6.0.post1  # via importlib-metadata, zipp
+cookies==2.2.1            # via responses
 coverage==5.1             # via -r requirements/test.in, pytest-cov
 ddt==1.4.1                # via -r requirements/test.in
+django-waffle==0.18.0     # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-utils
+edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-rest-api-client
 edx-lint==1.4.1           # via -r requirements/test.in
-edx-rest-api-client==1.9.2  # via -c requirements/constraints.txt, -r requirements/base.txt
 enum34==1.1.10            # via astroid, ddt
 funcsigs==1.0.2           # via mock, pytest
 futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, isort
-httpretty==0.8.10         # via -c requirements/constraints.txt, -r requirements/test.in
 idna==2.9                 # via -r requirements/base.txt, requests
 importlib-metadata==1.6.0  # via pluggy, pytest
 isort==4.3.21             # via pylint
 kombu==3.0.37             # via -r requirements/base.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
-mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
+mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in, responses
 more-itertools==5.0.0     # via pytest
+newrelic==5.12.1.141      # via -r requirements/base.txt, edx-django-utils
 packaging==20.4           # via pytest
 pathlib2==2.3.5           # via importlib-metadata, pytest
 pluggy==0.13.1            # via pytest
+psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
 py==1.8.1                 # via pytest
 pycodestyle==2.6.0        # via -r requirements/test.in
 pyjwt==1.7.1              # via -r requirements/base.txt, edx-rest-api-client
@@ -47,14 +50,15 @@ pylint==1.9.5             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.8.1         # via -r requirements/test.in
 pytest==4.6.10            # via -r requirements/test.in, pytest-cov
-pytz==2020.1              # via -r requirements/base.txt, celery
+pytz==2020.1              # via -r requirements/base.txt, celery, django
 redis==3.5.2              # via -r requirements/base.txt
-requests==2.23.0          # via -r requirements/base.txt, edx-rest-api-client, sailthru-client, slumber
+requests==2.23.0          # via -r requirements/base.txt, edx-rest-api-client, responses, sailthru-client, slumber
+responses==0.10.14        # via -r requirements/test.in
 sailthru-client==2.3.5    # via -r requirements/base.txt
 scandir==1.10.0           # via pathlib2
 simplejson==3.17.0        # via -r requirements/base.txt, sailthru-client
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.14.0               # via -r requirements/base.txt, astroid, edx-lint, mock, more-itertools, packaging, pathlib2, pylint, pytest, singledispatch
+six==1.14.0               # via -r requirements/base.txt, astroid, edx-lint, mock, more-itertools, packaging, pathlib2, pylint, pytest, responses, singledispatch
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 testfixtures==6.14.1      # via -r requirements/test.in
 urllib3==1.25.9           # via -r requirements/base.txt, requests

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -20,7 +20,7 @@ scandir==1.10.0           # via pathlib2
 singledispatch==3.4.0.3   # via importlib-resources
 six==1.14.0               # via packaging, pathlib2, tox, virtualenv
 toml==0.10.1              # via tox
-tox==3.15.0               # via -r requirements/tox.in
+tox==3.15.1               # via -r requirements/tox.in
 typing==3.7.4.1           # via importlib-resources
-virtualenv==20.0.20       # via tox
+virtualenv==20.0.21       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,9 @@ setenv =
     WORKER_CONFIGURATION_MODULE = ecommerce_worker.configuration.test
 deps =
     -r{toxinidir}/requirements/test.txt
+    py27: -r{toxinidir}/requirements/django.txt
+    py35: edx-rest-api-client==5.2.1
+    quality: -r{toxinidir}/requirements/django.txt
 commands =
     pytest ecommerce_worker --cov-branch --cov-report=html:build/coverage/html/html/ \
        --cov-report term --cov-report=xml:build/coverage/coverage.xml \


### PR DESCRIPTION
This PR make this:

  - Add tests in python3
  - Change httprety with responses
  - Use a different version of edx-rest-api-client for python3.5
