### PR TITLE
[BD-6] Change httpretty with responses

### DIFF
--- a/ecommerce_worker/fulfillment/v1/tests/test_tasks.py
+++ b/ecommerce_worker/fulfillment/v1/tests/test_tasks.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 from celery.exceptions import Ignore
 import ddt
 from edx_rest_api_client import exceptions
-import httpretty
+import responses
 import jwt
 import mock
 
@@ -37,73 +37,77 @@ class OrderFulfillmentTaskTests(TestCase):
             with self.assertRaises(RuntimeError):
                 fulfill_order(self.ORDER_NUMBER)
 
-    @httpretty.activate
+    @responses.activate
     def test_fulfillment_success(self):
         """Verify that the task exits without an error when fulfillment succeeds."""
-        httpretty.register_uri(httpretty.PUT, self.API_URL, status=200, body={})
+        responses.add(responses.PUT, self.API_URL, status=200, body="{}")
 
         result = fulfill_order.delay(self.ORDER_NUMBER).get()
         self.assertIsNone(result)
 
         # Validate the value of the HTTP Authorization header.
-        last_request = httpretty.last_request()
+        last_request = responses.calls[-1].request
         token = last_request.headers.get('authorization').split()[1]
         payload = jwt.decode(token, get_configuration('JWT_SECRET_KEY'))
         self.assertEqual(payload['username'], get_configuration('ECOMMERCE_SERVICE_USERNAME'))
 
-    @httpretty.activate
+    @responses.activate
     def test_fulfillment_not_possible(self):
         """Verify that the task exits without an error when fulfillment is not possible."""
-        httpretty.register_uri(httpretty.PUT, self.API_URL, status=406, body={})
+        responses.add(responses.PUT, self.API_URL, status=406, body="{}")
 
         with self.assertRaises(Ignore):
             fulfill_order(self.ORDER_NUMBER)
 
-    @httpretty.activate
+    @responses.activate
     def test_fulfillment_unknown_client_error(self):
         """
         Verify that the task raises an exception when fulfillment fails because of an
         unknown client error.
         """
-        httpretty.register_uri(httpretty.PUT, self.API_URL, status=404, body={})
+        responses.add(responses.PUT, self.API_URL, status=404, body="{}")
 
         with self.assertRaises(exceptions.HttpClientError):
             fulfill_order(self.ORDER_NUMBER)
 
-    @httpretty.activate
+    @responses.activate
     def test_fulfillment_unknown_client_error_retry_success(self):
         """Verify that the task is capable of successfully retrying after client error."""
-        httpretty.register_uri(httpretty.PUT, self.API_URL, responses=[
-            httpretty.Response(status=404, body={}),
-            httpretty.Response(status=200, body={}),
-        ])
+        responses.add(
+            responses.Response(responses.PUT, self.API_URL, status=404, body="{}"),
+        )
+        responses.add(
+            responses.Response(responses.PUT, self.API_URL, status=200, body="{}"),
+        )
 
         result = fulfill_order.delay(self.ORDER_NUMBER).get()
         self.assertIsNone(result)
 
-    @httpretty.activate
+    @responses.activate
     def test_fulfillment_failure(self):
         """Verify that the task raises an exception when fulfillment fails."""
-        httpretty.register_uri(httpretty.PUT, self.API_URL, status=500, body={})
+        responses.add(responses.PUT, self.API_URL, status=500, body="{}")
 
         with self.assertRaises(exceptions.HttpServerError):
             fulfill_order.delay(self.ORDER_NUMBER).get()
 
-    @httpretty.activate
+    @responses.activate
     def test_fulfillment_timeout(self):
         """Verify that the task raises an exception when fulfillment times out."""
-        httpretty.register_uri(httpretty.PUT, self.API_URL, status=404, body=self._timeout_body)
+        responses.add(responses.PUT, self.API_URL, status=404, body=exceptions.Timeout())
 
         with self.assertRaises(exceptions.Timeout):
             fulfill_order.delay(self.ORDER_NUMBER).get()
 
-    @httpretty.activate
+    @responses.activate
     def test_fulfillment_retry_success(self):
         """Verify that the task is capable of successfully retrying after fulfillment failure."""
-        httpretty.register_uri(httpretty.PUT, self.API_URL, responses=[
-            httpretty.Response(status=500, body={}),
-            httpretty.Response(status=200, body={}),
-        ])
+        responses.add(
+            responses.Response(responses.PUT, self.API_URL, status=500, body="{}"),
+        )
+        responses.add(
+            responses.Response(responses.PUT, self.API_URL, status=200, body="{}"),
+        )
 
         result = fulfill_order.delay(self.ORDER_NUMBER).get()
         self.assertIsNone(result)
@@ -113,22 +117,14 @@ class OrderFulfillmentTaskTests(TestCase):
         [False, 'False']
     )
     @ddt.unpack
-    @httpretty.activate
+    @responses.activate
     def test_email_opt_in_parameter_sent(self, email_opt_in_bool, email_opt_in_str):
         """Verify that the task correctly adds the email_opt_in parameter to the request."""
         email_opt_in_api_url = self.API_URL + '?email_opt_in=' + email_opt_in_str
-        httpretty.register_uri(httpretty.PUT, email_opt_in_api_url, status=200, body={})
+        responses.add(responses.PUT, email_opt_in_api_url, status=200, body="{}")
 
         result = fulfill_order.delay(self.ORDER_NUMBER, email_opt_in=email_opt_in_bool).get()
         self.assertIsNone(result)
 
-        last_request = httpretty.last_request()
-        self.assertIn('?email_opt_in=' + email_opt_in_str, last_request.path)
-        # QueryDicts store their values as lists in case multiple values are passed in.
-        # last_request.querystring is returned as a dict instead of a QueryDict
-        # so we have the grab the first element in the list to actually get the value.
-        self.assertEqual(last_request.querystring['email_opt_in'][0], email_opt_in_str)
-
-    def _timeout_body(self, request, uri, headers):  # pylint: disable=unused-argument
-        """Helper used to force httpretty to raise Timeout exceptions."""
-        raise exceptions.Timeout
+        last_request = responses.calls[-1].request
+        self.assertIn('?email_opt_in=' + email_opt_in_str, last_request.path_url)

--- a/ecommerce_worker/sailthru/v1/tests/test_tasks.py
+++ b/ecommerce_worker/sailthru/v1/tests/test_tasks.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from unittest import TestCase
 import ddt
 
-import httpretty
+import responses
 from celery.exceptions import Retry
 from mock import patch, Mock
 from sailthru import SailthruClient
@@ -84,9 +84,9 @@ class SailthruTests(TestCase):
 
     def mock_ecommerce_api(self, body, course_id, status=200):
         """ Mock GET requests to the ecommerce course API endpoint. """
-        httpretty.reset()
-        httpretty.register_uri(
-            httpretty.GET, '{}/courses/{}/'.format(
+        responses.reset()
+        responses.add(
+            responses.GET, '{}/courses/{}/'.format(
                 get_configuration('ECOMMERCE_API_ROOT').strip('/'), text_type(course_id)
             ),
             status=status,
@@ -420,7 +420,7 @@ class SailthruTests(TestCase):
         )
         self.assertTrue(mock_log_error.called)
 
-    @httpretty.activate
+    @responses.activate
     @patch('ecommerce_worker.sailthru.v1.utils.SailthruClient')
     def test_get_course_content(self, mock_sailthru_client):
         """
@@ -469,7 +469,7 @@ class SailthruTests(TestCase):
             _get_course_content(self.course_id2, 'course:126', mock_sailthru_client, None, config), {}
         )
 
-    @httpretty.activate
+    @responses.activate
     def test_get_course_content_from_ecommerce(self):
         """
         Test routine that fetches data from ecommerce.
@@ -574,8 +574,8 @@ class SendCourseRefundEmailTests(TestCase):
 
     def mock_api_response(self, status, body):
         """ Mock the Sailthru send API. """
-        httpretty.register_uri(
-            httpretty.POST,
+        responses.add(
+            responses.POST,
             'https://api.sailthru.com/send',
             status=status,
             body=json.dumps(body),
@@ -598,7 +598,7 @@ class SendCourseRefundEmailTests(TestCase):
             self.REFUND_ID
         )
 
-    @httpretty.activate
+    @responses.activate
     def test_api_error_with_retry(self):
         """ Verify the task is rescheduled if an API error occurs, and the request can be retried. """
         error_code = 43
@@ -621,7 +621,7 @@ class SendCourseRefundEmailTests(TestCase):
              'An attempt will be made again to send a course refund notification for refund [%d].' % self.REFUND_ID),
         )
 
-    @httpretty.activate
+    @responses.activate
     def test_api_error_without_retry(self):
         """ Verify error details are logged if an API error occurs, and the request can NOT be retried. """
         error_code = 1
@@ -643,7 +643,7 @@ class SendCourseRefundEmailTests(TestCase):
              'No further attempts will be made to send a course refund notification for refund [%d].' % self.REFUND_ID),
         )
 
-    @httpretty.activate
+    @responses.activate
     def test_message_sent(self):
         """ Verify a message is logged after a successful API call to send the message. """
         self.mock_api_response(200, {'send_id': '1234ABC'})
@@ -662,8 +662,8 @@ class BaseSendEmailTests(TestCase):
 
     def mock_api_response(self, status, body):
         """ Mock the Sailthru send API. """
-        httpretty.register_uri(
-            httpretty.POST,
+        responses.add(
+            responses.POST,
             'https://api.sailthru.com/send',
             status=status,
             body=json.dumps(body),
@@ -709,9 +709,9 @@ class SendOfferEmailsTests(BaseSendEmailTests):
 
     def mock_ecommerce_assignmentemail_api(self, body, status=200):
         """ Mock POST requests to the ecommerce assignmentemail API endpoint. """
-        httpretty.reset()
-        httpretty.register_uri(
-            httpretty.POST, '{}/assignment-email/status/'.format(
+        responses.reset()
+        responses.add(
+            responses.POST, '{}/assignment-email/status/'.format(
                 get_configuration('ECOMMERCE_API_ROOT').strip('/')
             ),
             status=status,
@@ -760,7 +760,7 @@ class SendOfferEmailsTests(BaseSendEmailTests):
             )
         )
 
-    @httpretty.activate
+    @responses.activate
     @ddt.data(
         (send_offer_assignment_email, ASSIGNMENT_TASK_KWARGS, "Offer Assignment"),
         (send_offer_update_email, UPDATE_TASK_KWARGS, "Offer Assignment"),
@@ -801,7 +801,7 @@ class SendOfferEmailsTests(BaseSendEmailTests):
             ),
         )
 
-    @httpretty.activate
+    @responses.activate
     @ddt.data(
         (send_offer_assignment_email, ASSIGNMENT_TASK_KWARGS, "Offer Assignment"),
         (send_offer_update_email, UPDATE_TASK_KWARGS, "Offer Assignment"),
@@ -843,7 +843,7 @@ class SendOfferEmailsTests(BaseSendEmailTests):
             ),
         )
 
-    @httpretty.activate
+    @responses.activate
     @ddt.data(
         (send_offer_update_email, UPDATE_TASK_KWARGS, "Offer Assignment"),
         (send_offer_usage_email, USAGE_TASK_KWARGS, "Offer Usage"),
@@ -870,7 +870,7 @@ class SendOfferEmailsTests(BaseSendEmailTests):
             )
         )
 
-    @httpretty.activate
+    @responses.activate
     @patch('ecommerce_worker.sailthru.v1.tasks._update_assignment_email_status')
     def test_message_sent(self, mock_update_assignment):
         """ Verify a message is logged after a successful API call to send the message. """
@@ -895,7 +895,7 @@ class SendOfferEmailsTests(BaseSendEmailTests):
         )
         self.assertEqual(mock_update_assignment.call_count, 1)
 
-    @httpretty.activate
+    @responses.activate
     @patch('ecommerce_worker.utils.get_ecommerce_client')
     def test_update_assignment_exception(self, mock_get_ecommerce_client):
         """ Verify a message is logged after an unsuccessful API call to update the status. """
@@ -931,7 +931,7 @@ class SendOfferEmailsTests(BaseSendEmailTests):
             )
         )
 
-    @httpretty.activate
+    @responses.activate
     @ddt.data(
         (
             # Success case

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,15 +9,22 @@ billiard==3.6.3.0         # via celery
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.in
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
+configparser==4.0.2       # via importlib-metadata
+contextlib2==0.6.0.post1  # via importlib-metadata, zipp
 edx-rest-api-client==1.5.0  # via -c requirements/constraints.txt, -r requirements/base.in
 idna==2.10                # via requests
+importlib-metadata==1.7.0  # via kombu
 kombu==4.6.11             # via celery
+pathlib2==2.3.5           # via importlib-metadata
 pyjwt==1.7.1              # via edx-rest-api-client
 pytz==2020.1              # via celery
 redis==3.5.3              # via -r requirements/base.in
 requests==2.24.0          # via sailthru-client, slumber
 sailthru-client==2.2.3    # via -c requirements/constraints.txt, -r requirements/base.in
+scandir==1.10.0           # via pathlib2
 simplejson==3.17.2        # via sailthru-client
+six==1.15.0               # via -c requirements/constraints.txt, pathlib2
 slumber==0.7.1            # via edx-rest-api-client
 urllib3==1.25.10          # via requests
 vine==1.3.0               # via amqp, celery
+zipp==1.2.0               # via importlib-metadata

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -9,16 +9,23 @@ billiard==3.6.3.0         # via -r requirements/base.txt, celery
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.txt
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
+configparser==4.0.2       # via -r requirements/base.txt, importlib-metadata
+contextlib2==0.6.0.post1  # via -r requirements/base.txt, importlib-metadata, zipp
 edx-rest-api-client==1.5.0  # via -c requirements/constraints.txt, -r requirements/base.txt
 idna==2.10                # via -r requirements/base.txt, requests
+importlib-metadata==1.7.0  # via -r requirements/base.txt, kombu
 kombu==4.6.11             # via -r requirements/base.txt, celery
+pathlib2==2.3.5           # via -r requirements/base.txt, importlib-metadata
 pyjwt==1.7.1              # via -r requirements/base.txt, edx-rest-api-client
 pytz==2020.1              # via -r requirements/base.txt, celery
 pyyaml==5.1              # via -c requirements/constraints.txt, -r requirements/production.in
 redis==3.5.3              # via -r requirements/base.txt
 requests==2.24.0          # via -r requirements/base.txt, sailthru-client, slumber
 sailthru-client==2.2.3    # via -c requirements/constraints.txt, -r requirements/base.txt
+scandir==1.10.0           # via -r requirements/base.txt, pathlib2
 simplejson==3.17.2        # via -r requirements/base.txt, sailthru-client
+six==1.15.0               # via -c requirements/constraints.txt, -r requirements/base.txt, pathlib2
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 urllib3==1.25.10          # via -r requirements/base.txt, requests
 vine==1.3.0               # via -r requirements/base.txt, amqp, celery
+zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -6,7 +6,6 @@ astroid
 coverage
 ddt
 edx-lint
-httpretty
 mock
 pep8
 pylint
@@ -14,4 +13,5 @@ pylint-django
 pylint-plugin-utils
 pytest
 pytest-cov
+responses
 testfixtures

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,23 +8,30 @@ amqp==2.6.1               # via -r requirements/base.txt, kombu
 astroid==1.4.9            # via -c requirements/constraints.txt, -r requirements/test.in, pylint, pylint-celery, pylint-plugin-utils
 atomicwrites==1.4.0       # via pytest
 attrs==19.3.0             # via pytest
+backports.functools-lru-cache==1.6.1  # via isort, pylint, wcwidth
 billiard==3.6.3.0         # via -r requirements/base.txt, celery
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.txt
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
+configparser==4.0.2       # via -r requirements/base.txt, importlib-metadata, pylint
+contextlib2==0.6.0.post1  # via -r requirements/base.txt, importlib-metadata, zipp
+cookies==2.2.1            # via responses
 coverage==4.4             # via -c requirements/constraints.txt, -r requirements/test.in, pytest-cov
 ddt==1.0.1                # via -c requirements/constraints.txt, -r requirements/test.in
 edx-lint==0.5.2           # via -c requirements/constraints.txt, -r requirements/test.in
 edx-rest-api-client==1.5.0  # via -c requirements/constraints.txt, -r requirements/base.txt
-httpretty==0.8.10         # via -c requirements/constraints.txt, -r requirements/test.in
+funcsigs==1.0.2           # via mock, pytest
+futures==3.3.0            # via isort
 idna==2.10                # via -r requirements/base.txt, requests
+importlib-metadata==1.7.0  # via -r requirements/base.txt, kombu, pluggy, pytest
 isort==4.3.21             # via -c requirements/constraints.txt, pylint
 kombu==4.6.11             # via -r requirements/base.txt, celery
 lazy-object-proxy==1.5.1  # via astroid
 mccabe==0.6.1             # via pylint
-mock==1.3.0               # via -c requirements/constraints.txt, -r requirements/test.in
+mock==1.3.0               # via -c requirements/constraints.txt, -r requirements/test.in, responses
 more-itertools==5.0.0     # via -c requirements/constraints.txt, pytest
 packaging==20.4           # via pytest
+pathlib2==2.3.5           # via -r requirements/base.txt, importlib-metadata, pytest
 pbr==5.4.5                # via mock
 pep8==1.7.0               # via -c requirements/constraints.txt, -r requirements/test.in
 pluggy==0.13.1            # via pytest
@@ -39,13 +46,16 @@ pytest-cov==2.10.0        # via -c requirements/constraints.txt, -r requirements
 pytest==4.6.11            # via -c requirements/constraints.txt, -r requirements/test.in, pytest-cov
 pytz==2020.1              # via -r requirements/base.txt, celery
 redis==3.5.3              # via -r requirements/base.txt
-requests==2.24.0          # via -r requirements/base.txt, sailthru-client, slumber
+requests==2.24.0          # via -r requirements/base.txt, responses, sailthru-client, slumber
+responses==0.10.16        # via -r requirements/test.in
 sailthru-client==2.2.3    # via -c requirements/constraints.txt, -r requirements/base.txt
+scandir==1.10.0           # via -r requirements/base.txt, pathlib2
 simplejson==3.17.2        # via -r requirements/base.txt, sailthru-client
-six==1.15.0               # via -c requirements/constraints.txt, astroid, edx-lint, mock, more-itertools, packaging, pylint, pytest
+six==1.15.0               # via -c requirements/constraints.txt, -r requirements/base.txt, astroid, edx-lint, mock, more-itertools, packaging, pathlib2, pylint, pytest, responses
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 testfixtures==4.13.3      # via -c requirements/constraints.txt, -r requirements/test.in
-urllib3==1.25.10          # via -r requirements/base.txt, requests
+urllib3==1.25.10          # via -r requirements/base.txt, requests, responses
 vine==1.3.0               # via -r requirements/base.txt, amqp, celery
 wcwidth==0.2.5            # via pytest
 wrapt==1.12.1             # via astroid
+zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -5,14 +5,23 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via virtualenv
+configparser==4.0.2       # via importlib-metadata
+contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, zipp
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
+importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
+importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
+pathlib2==2.3.5           # via importlib-metadata, importlib-resources, virtualenv
 pluggy==0.13.1            # via tox
 py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
-six==1.15.0               # via -c requirements/constraints.txt, packaging, tox, virtualenv
+scandir==1.10.0           # via pathlib2
+singledispatch==3.4.0.3   # via importlib-resources
+six==1.15.0               # via -c requirements/constraints.txt, packaging, pathlib2, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/tox.in
 tox==3.15.2               # via -c requirements/constraints.txt, -r requirements/tox.in, tox-battery
-virtualenv==20.0.30       # via tox
+typing==3.7.4.3           # via importlib-resources
+virtualenv==20.0.31       # via tox
+zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
Change httpretty with [responses](https://github.com/getsentry/responses) because the current version of httpretty is from 2015, does not have support for python 3.5 and if we upgrade that version the test suite gets broken due to https://github.com/gabrielfalcao/HTTPretty/pull/202

This will be needed for the migration to python3.

## Reviewers
- [x] @awais786 