### PR TITLE
[WIP] REV-1303: update pyyaml version to 4.2b1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,6 +11,7 @@ certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 edx-rest-api-client==1.5.0  # via -c requirements/constraints.txt, -r requirements/base.in
 idna==2.10                # via requests
+importlib-metadata==1.7.0  # via kombu
 kombu==4.6.11             # via celery
 pyjwt==1.7.1              # via edx-rest-api-client
 pytz==2020.1              # via celery
@@ -21,3 +22,4 @@ simplejson==3.17.2        # via sailthru-client
 slumber==0.7.1            # via edx-rest-api-client
 urllib3==1.25.10          # via requests
 vine==1.3.0               # via amqp, celery
+zipp==3.1.0               # via importlib-metadata

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -23,7 +23,6 @@ pylint-plugin-utils==0.2.1
 pylint==1.6.4
 pytest-cov==2.10.0
 pytest==4.6.11
-PyYAML==5.1
 sailthru-client==2.2.3
 testfixtures==4.13.3
 tox==3.15.2

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -23,7 +23,7 @@ pylint-plugin-utils==0.2.1
 pylint==1.6.4
 pytest-cov==2.10.0
 pytest==4.6.11
-PyYAML==3.11
+PyYAML==4.2b1
 sailthru-client==2.2.3
 testfixtures==4.13.3
 tox==3.15.2

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -23,7 +23,7 @@ pylint-plugin-utils==0.2.1
 pylint==1.6.4
 pytest-cov==2.10.0
 pytest==4.6.11
-PyYAML==4.2b1
+PyYAML==5.1
 sailthru-client==2.2.3
 testfixtures==4.13.3
 tox==3.15.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -14,7 +14,7 @@ idna==2.10                # via -r requirements/base.txt, requests
 kombu==4.6.11             # via -r requirements/base.txt, celery
 pyjwt==1.7.1              # via -r requirements/base.txt, edx-rest-api-client
 pytz==2020.1              # via -r requirements/base.txt, celery
-pyyaml==4.2b1             # via -c requirements/constraints.txt, -r requirements/production.in
+pyyaml==5.1             # via -c requirements/constraints.txt, -r requirements/production.in
 redis==3.5.3              # via -r requirements/base.txt
 requests==2.24.0          # via -r requirements/base.txt, sailthru-client, slumber
 sailthru-client==2.2.3    # via -c requirements/constraints.txt, -r requirements/base.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -14,7 +14,7 @@ idna==2.10                # via -r requirements/base.txt, requests
 kombu==4.6.11             # via -r requirements/base.txt, celery
 pyjwt==1.7.1              # via -r requirements/base.txt, edx-rest-api-client
 pytz==2020.1              # via -r requirements/base.txt, celery
-pyyaml==5.1             # via -c requirements/constraints.txt, -r requirements/production.in
+pyyaml==5.1               # via -c requirements/constraints.txt, -r requirements/production.in
 redis==3.5.3              # via -r requirements/base.txt
 requests==2.24.0          # via -r requirements/base.txt, sailthru-client, slumber
 sailthru-client==2.2.3    # via -c requirements/constraints.txt, -r requirements/base.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -14,7 +14,7 @@ idna==2.10                # via -r requirements/base.txt, requests
 kombu==4.6.11             # via -r requirements/base.txt, celery
 pyjwt==1.7.1              # via -r requirements/base.txt, edx-rest-api-client
 pytz==2020.1              # via -r requirements/base.txt, celery
-pyyaml==3.11              # via -c requirements/constraints.txt, -r requirements/production.in
+pyyaml==4.2b1             # via -c requirements/constraints.txt, -r requirements/production.in
 redis==3.5.3              # via -r requirements/base.txt
 requests==2.24.0          # via -r requirements/base.txt, sailthru-client, slumber
 sailthru-client==2.2.3    # via -c requirements/constraints.txt, -r requirements/base.txt

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -7,6 +7,7 @@
 appdirs==1.4.4            # via virtualenv
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
+importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
 py==1.9.0                 # via tox
@@ -15,4 +16,5 @@ six==1.15.0               # via -c requirements/constraints.txt, packaging, tox,
 toml==0.10.1              # via tox
 tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/tox.in
 tox==3.15.2               # via -c requirements/constraints.txt, -r requirements/tox.in, tox-battery
-virtualenv==20.0.30       # via tox
+virtualenv==20.0.31       # via tox
+zipp==3.1.0               # via importlib-metadata

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def is_requirement(line):
 
 setup(
     name='edx-ecommerce-worker',
-    version='0.8.2',
+    version='0.8.3',
     description='Celery tasks supporting the operations of edX\'s ecommerce service',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
We got an alert that we need to update this version for a security vulnerability, but dependabot wasn't able to make the PR because "one or more other dependencies require a version that is incompatible with this update". These tests here succeed, but I'm not seeing whether/where the travis-ci task checks version conflicts. Following up to see where clashing versions typically shows up, so I can look there :)

Relevant ticket: https://openedx.atlassian.net/browse/REV-1303