### PR TITLE
Rev-1303 pyyaml upgrade: UPDATE CONSTRAINT VERSION

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,20 +4,41 @@
 #
 #    make upgrade
 #
-amqp==2.6.1               # via kombu
-billiard==3.6.3.0         # via celery
-celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.in
+attrs==20.2.0             # via jsonschema
+backports.shutil-get-terminal-size==1.0.0  # via docker-compose
+backports.ssl-match-hostname==3.7.0.1  # via docker, docker-compose
+bcrypt==3.1.7             # via paramiko
+cached-property==1.5.1    # via docker-compose
 certifi==2020.6.20        # via requests
+cffi==1.14.2              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
-edx-rest-api-client==1.5.0  # via -c requirements/constraints.txt, -r requirements/base.in
+configparser==4.0.2       # via importlib-metadata
+contextlib2==0.6.0.post1  # via importlib-metadata, zipp
+cryptography==3.1         # via paramiko
+distro==1.5.0             # via docker-compose
+docker-compose==1.26.2    # via -r requirements/base.in
+docker[ssh]==4.3.1        # via docker-compose
+dockerpty==0.4.1          # via docker-compose
+docopt==0.6.2             # via docker-compose
+enum34==1.1.10            # via cryptography, docker-compose
+functools32==3.2.3.post2  # via jsonschema
 idna==2.10                # via requests
-kombu==4.6.11             # via celery
-pyjwt==1.7.1              # via edx-rest-api-client
-pytz==2020.1              # via celery
-redis==3.5.3              # via -r requirements/base.in
-requests==2.24.0          # via sailthru-client, slumber
-sailthru-client==2.2.3    # via -c requirements/constraints.txt, -r requirements/base.in
-simplejson==3.17.2        # via sailthru-client
-slumber==0.7.1            # via edx-rest-api-client
+importlib-metadata==1.7.0  # via jsonschema
+ipaddress==1.0.23         # via cryptography, docker, docker-compose
+jsonschema==3.2.0         # via docker-compose
+paramiko==2.7.2           # via docker
+pathlib2==2.3.5           # via importlib-metadata
+pycparser==2.20           # via cffi
+pynacl==1.4.0             # via paramiko
+pyrsistent==0.16.1        # via jsonschema
+python-dotenv==0.14.0     # via docker-compose
+pyyaml==5.3.1             # via -r requirements/base.in, docker-compose
+requests==2.24.0          # via docker, docker-compose
+scandir==1.10.0           # via pathlib2
+six==1.15.0               # via bcrypt, cryptography, docker, docker-compose, dockerpty, jsonschema, pathlib2, pynacl, pyrsistent, websocket-client
+subprocess32==3.5.4       # via docker-compose
+texttable==1.6.3          # via docker-compose
+typing==3.7.4.3           # via python-dotenv
 urllib3==1.25.10          # via requests
-vine==1.3.0               # via amqp, celery
+websocket-client==0.57.0  # via docker, docker-compose
+zipp==1.2.0               # via importlib-metadata

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -23,7 +23,7 @@ pylint-plugin-utils==0.2.1
 pylint==1.6.4
 pytest-cov==2.10.0
 pytest==4.6.11
-PyYAML==3.11
+PyYAML==5.1
 sailthru-client==2.2.3
 testfixtures==4.13.3
 tox==3.15.2

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def is_requirement(line):
 
 setup(
     name='edx-ecommerce-worker',
-    version='0.8.2',
+    version='0.8.3',
     description='Celery tasks supporting the operations of edX\'s ecommerce service',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
We got an alert that we need to update pyyaml for a security vulnerability, but dependabot wasn't able to make the PR because "one or more other dependencies require a version that is incompatible with this update". I've removed it from the constraints.txt (so it can be upgraded), applied the updates from 'make upgrade', and increased the minor release version for ecommerce worker.

Relevant ticket: https://openedx.atlassian.net/browse/REV-1303