### PR TITLE
Rev 1303 update pyyaml fresh: remove constraint

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,15 +9,22 @@ billiard==3.6.3.0         # via celery
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.in
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
+configparser==4.0.2       # via importlib-metadata
+contextlib2==0.6.0.post1  # via importlib-metadata, zipp
 edx-rest-api-client==1.5.0  # via -c requirements/constraints.txt, -r requirements/base.in
 idna==2.10                # via requests
+importlib-metadata==1.7.0  # via kombu
 kombu==4.6.11             # via celery
+pathlib2==2.3.5           # via importlib-metadata
 pyjwt==1.7.1              # via edx-rest-api-client
 pytz==2020.1              # via celery
 redis==3.5.3              # via -r requirements/base.in
 requests==2.24.0          # via sailthru-client, slumber
 sailthru-client==2.2.3    # via -c requirements/constraints.txt, -r requirements/base.in
+scandir==1.10.0           # via pathlib2
 simplejson==3.17.2        # via sailthru-client
+six==1.15.0               # via -c requirements/constraints.txt, pathlib2
 slumber==0.7.1            # via edx-rest-api-client
 urllib3==1.25.10          # via requests
 vine==1.3.0               # via amqp, celery
+zipp==1.2.0               # via importlib-metadata

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -23,7 +23,6 @@ pylint-plugin-utils==0.2.1
 pylint==1.6.4
 pytest-cov==2.10.0
 pytest==4.6.11
-PyYAML==3.11
 sailthru-client==2.2.3
 testfixtures==4.13.3
 tox==3.15.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -9,16 +9,23 @@ billiard==3.6.3.0         # via -r requirements/base.txt, celery
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.txt
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
+configparser==4.0.2       # via -r requirements/base.txt, importlib-metadata
+contextlib2==0.6.0.post1  # via -r requirements/base.txt, importlib-metadata, zipp
 edx-rest-api-client==1.5.0  # via -c requirements/constraints.txt, -r requirements/base.txt
 idna==2.10                # via -r requirements/base.txt, requests
+importlib-metadata==1.7.0  # via -r requirements/base.txt, kombu
 kombu==4.6.11             # via -r requirements/base.txt, celery
+pathlib2==2.3.5           # via -r requirements/base.txt, importlib-metadata
 pyjwt==1.7.1              # via -r requirements/base.txt, edx-rest-api-client
 pytz==2020.1              # via -r requirements/base.txt, celery
-pyyaml==3.11              # via -c requirements/constraints.txt, -r requirements/production.in
+pyyaml==5.3.1             # via -r requirements/production.in
 redis==3.5.3              # via -r requirements/base.txt
 requests==2.24.0          # via -r requirements/base.txt, sailthru-client, slumber
 sailthru-client==2.2.3    # via -c requirements/constraints.txt, -r requirements/base.txt
+scandir==1.10.0           # via -r requirements/base.txt, pathlib2
 simplejson==3.17.2        # via -r requirements/base.txt, sailthru-client
+six==1.15.0               # via -c requirements/constraints.txt, -r requirements/base.txt, pathlib2
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 urllib3==1.25.10          # via -r requirements/base.txt, requests
 vine==1.3.0               # via -r requirements/base.txt, amqp, celery
+zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,17 +7,23 @@
 amqp==2.6.1               # via -r requirements/base.txt, kombu
 astroid==1.4.9            # via -c requirements/constraints.txt, -r requirements/test.in, pylint, pylint-celery, pylint-plugin-utils
 atomicwrites==1.4.0       # via pytest
-attrs==19.3.0             # via pytest
+attrs==20.2.0             # via pytest
+backports.functools-lru-cache==1.6.1  # via isort, pylint, wcwidth
 billiard==3.6.3.0         # via -r requirements/base.txt, celery
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.txt
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
+configparser==4.0.2       # via -r requirements/base.txt, importlib-metadata, pylint
+contextlib2==0.6.0.post1  # via -r requirements/base.txt, importlib-metadata, zipp
 coverage==4.4             # via -c requirements/constraints.txt, -r requirements/test.in, pytest-cov
 ddt==1.0.1                # via -c requirements/constraints.txt, -r requirements/test.in
 edx-lint==0.5.2           # via -c requirements/constraints.txt, -r requirements/test.in
 edx-rest-api-client==1.5.0  # via -c requirements/constraints.txt, -r requirements/base.txt
+funcsigs==1.0.2           # via mock, pytest
+futures==3.3.0            # via isort
 httpretty==0.8.10         # via -c requirements/constraints.txt, -r requirements/test.in
 idna==2.10                # via -r requirements/base.txt, requests
+importlib-metadata==1.7.0  # via -r requirements/base.txt, kombu, pluggy, pytest
 isort==4.3.21             # via -c requirements/constraints.txt, pylint
 kombu==4.6.11             # via -r requirements/base.txt, celery
 lazy-object-proxy==1.5.1  # via astroid
@@ -25,7 +31,8 @@ mccabe==0.6.1             # via pylint
 mock==1.3.0               # via -c requirements/constraints.txt, -r requirements/test.in
 more-itertools==5.0.0     # via -c requirements/constraints.txt, pytest
 packaging==20.4           # via pytest
-pbr==5.4.5                # via mock
+pathlib2==2.3.5           # via -r requirements/base.txt, importlib-metadata, pytest
+pbr==5.5.0                # via mock
 pep8==1.7.0               # via -c requirements/constraints.txt, -r requirements/test.in
 pluggy==0.13.1            # via pytest
 py==1.9.0                 # via pytest
@@ -41,11 +48,13 @@ pytz==2020.1              # via -r requirements/base.txt, celery
 redis==3.5.3              # via -r requirements/base.txt
 requests==2.24.0          # via -r requirements/base.txt, sailthru-client, slumber
 sailthru-client==2.2.3    # via -c requirements/constraints.txt, -r requirements/base.txt
+scandir==1.10.0           # via -r requirements/base.txt, pathlib2
 simplejson==3.17.2        # via -r requirements/base.txt, sailthru-client
-six==1.15.0               # via -c requirements/constraints.txt, astroid, edx-lint, mock, more-itertools, packaging, pylint, pytest
+six==1.15.0               # via -c requirements/constraints.txt, -r requirements/base.txt, astroid, edx-lint, mock, more-itertools, packaging, pathlib2, pylint, pytest
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 testfixtures==4.13.3      # via -c requirements/constraints.txt, -r requirements/test.in
 urllib3==1.25.10          # via -r requirements/base.txt, requests
 vine==1.3.0               # via -r requirements/base.txt, amqp, celery
 wcwidth==0.2.5            # via pytest
 wrapt==1.12.1             # via astroid
+zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -5,14 +5,23 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via virtualenv
+configparser==4.0.2       # via importlib-metadata
+contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, zipp
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
+importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
+importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
+pathlib2==2.3.5           # via importlib-metadata, importlib-resources, virtualenv
 pluggy==0.13.1            # via tox
 py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
-six==1.15.0               # via -c requirements/constraints.txt, packaging, tox, virtualenv
+scandir==1.10.0           # via pathlib2
+singledispatch==3.4.0.3   # via importlib-resources
+six==1.15.0               # via -c requirements/constraints.txt, packaging, pathlib2, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/tox.in
 tox==3.15.2               # via -c requirements/constraints.txt, -r requirements/tox.in, tox-battery
-virtualenv==20.0.30       # via tox
+typing==3.7.4.3           # via importlib-resources
+virtualenv==20.0.31       # via tox
+zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def is_requirement(line):
 
 setup(
     name='edx-ecommerce-worker',
-    version='0.8.2',
+    version='0.8.3',
     description='Celery tasks supporting the operations of edX\'s ecommerce service',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
We got an alert that we need to update pyyaml for a security vulnerability, but dependabot wasn't able to make the PR because "one or more other dependencies require a version that is incompatible with this update". I've removed it from the constraints.txt (so it can be upgraded), applied the updates from 'make upgrade', and increased the minor release version for ecommerce worker.

Relevant ticket: https://openedx.atlassian.net/browse/REV-1303