### PR TITLE
REV-1303: update pyyaml version directly

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -23,7 +23,7 @@ pylint-plugin-utils==0.2.1
 pylint==1.6.4
 pytest-cov==2.10.0
 pytest==4.6.11
-PyYAML==5.2
+PyYAML==5.1
 sailthru-client==2.2.3
 testfixtures==4.13.3
 tox==3.15.2

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -23,7 +23,7 @@ pylint-plugin-utils==0.2.1
 pylint==1.6.4
 pytest-cov==2.10.0
 pytest==4.6.11
-PyYAML==3.11
+PyYAML==5.2
 sailthru-client==2.2.3
 testfixtures==4.13.3
 tox==3.15.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -14,7 +14,7 @@ idna==2.10                # via -r requirements/base.txt, requests
 kombu==4.6.11             # via -r requirements/base.txt, celery
 pyjwt==1.7.1              # via -r requirements/base.txt, edx-rest-api-client
 pytz==2020.1              # via -r requirements/base.txt, celery
-pyyaml==3.11              # via -c requirements/constraints.txt, -r requirements/production.in
+pyyaml==5.1              # via -c requirements/constraints.txt, -r requirements/production.in
 redis==3.5.3              # via -r requirements/base.txt
 requests==2.24.0          # via -r requirements/base.txt, sailthru-client, slumber
 sailthru-client==2.2.3    # via -c requirements/constraints.txt, -r requirements/base.txt

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def is_requirement(line):
 
 setup(
     name='edx-ecommerce-worker',
-    version='0.8.2',
+    version='0.8.3',
     description='Celery tasks supporting the operations of edX\'s ecommerce service',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
We got an alert that we need to update pyyaml for a security vulnerability, but dependabot wasn't able to make the PR because "one or more other dependencies require a version that is incompatible with this update". Generally we'd want to run 'make upgrade', but that's overdue and pulls in a dozenish additional libraries even on master, unrelated to pyyaml. (pyyaml doesn't appear in any of the include 'via' comments for the new libraries)

Since there are no other dependencies, we're safe to update the version directly where it appears.  (Also updating ecommerce-worker version as per guidelines [here](https://openedx.atlassian.net/wiki/spaces/SOL/pages/1756856407/Releasing+ecommerce-worker)). See fuller context on the process for upgrading library versions in my notes [here](https://docs.google.com/document/d/1Cgepomb8Tpd0DmgbDGVYTIy1xZoryNMDWGyhYrj_4Vw/edit). 

Relevant ticket: https://openedx.atlassian.net/browse/REV-1303