### PR TITLE
ENT-3589 | Added a new task for sending the code assignment nudge ema…

### DIFF
--- a/ecommerce_worker/sailthru/v1/tasks.py
+++ b/ecommerce_worker/sailthru/v1/tasks.py
@@ -384,7 +384,7 @@ def send_offer_assignment_email(self, user_email, offer_assignment_id, subject, 
             'email_body': email_body,
             'base_enterprise_url': base_enterprise_url,
         },
-        logger_prefix="Offer Assignment",
+        logger_prefix='Offer Assignment',
         site_code=site_code,
         template='enterprise_portal_email'
     )
@@ -460,7 +460,7 @@ def send_offer_update_email(self, user_email, subject, email_body, site_code=Non
             'subject': subject,
             'email_body': email_body
         },
-        logger_prefix="Offer Assignment",
+        logger_prefix='Offer Assignment',
         site_code=site_code,
         template='enterprise_portal_email'
     )
@@ -489,10 +489,39 @@ def send_offer_usage_email(self, emails, subject, email_body, site_code=None):
             'subject': subject,
             'email_body': email_body
         },
-        logger_prefix="Offer Usage",
+        logger_prefix='Offer Usage',
         site_code=site_code,
         template='assignment_email'
     )
     _, is_eligible_for_retry = notification.send(is_multi_send=True)
+    if is_eligible_for_retry:
+        schedule_retry(self, config)
+
+
+@shared_task(bind=True, ignore_result=True)
+def send_code_assignment_nudge_email(self, email, subject, email_body, site_code=None):
+    """
+    Sends the code assignment nudge email.
+
+    Args:
+        self: Ignore.
+        email (str): Recipient's email address.
+        subject (str): Email subject.
+        email_body (str): The body of the email.
+        site_code (str): Identifier of the site sending the email.
+    """
+    config = get_sailthru_configuration(site_code)
+    notification = Notification(
+        config=config,
+        emails=email,
+        email_vars={
+            'subject': subject,
+            'email_body': email_body
+        },
+        logger_prefix='Code Assignment Nudge Email',
+        site_code=site_code,
+        template='assignment_email'
+    )
+    _, is_eligible_for_retry = notification.send()
     if is_eligible_for_retry:
         schedule_retry(self, config)

--- a/ecommerce_worker/sailthru/v1/tests/test_tasks.py
+++ b/ecommerce_worker/sailthru/v1/tests/test_tasks.py
@@ -16,10 +16,16 @@ from requests.exceptions import RequestException
 from six import text_type
 from ecommerce_worker.sailthru.v1.exceptions import SailthruError
 from ecommerce_worker.sailthru.v1.tasks import (
-    update_course_enrollment, _update_unenrolled_list, _get_course_content, _get_course_content_from_ecommerce,
-    send_course_refund_email, send_offer_assignment_email, send_offer_update_email, send_offer_usage_email,
     _update_assignment_email_status,
-
+    _update_unenrolled_list,
+    _get_course_content,
+    _get_course_content_from_ecommerce,
+    send_code_assignment_nudge_email,
+    send_course_refund_email,
+    send_offer_assignment_email,
+    send_offer_update_email,
+    send_offer_usage_email,
+    update_course_enrollment,
 )
 from ecommerce_worker.utils import get_configuration
 
@@ -706,6 +712,12 @@ class SendOfferEmailsTests(BaseSendEmailTests):
         'email_body': EMAIL_BODY,
     }
 
+    NUDGE_TASK_KWARGS = {
+        'email': USER_EMAIL,
+        'subject': SUBJECT,
+        'email_body': EMAIL_BODY,
+    }
+
     def execute_task(self):
         """ Execute the send_offer_assignment_email task. """
         send_offer_assignment_email(**self.ASSIGNMENT_TASK_KWARGS)
@@ -726,6 +738,7 @@ class SendOfferEmailsTests(BaseSendEmailTests):
         (send_offer_assignment_email, ASSIGNMENT_TASK_KWARGS, "Offer Assignment"),
         (send_offer_update_email, UPDATE_TASK_KWARGS, "Offer Assignment"),
         (send_offer_usage_email, USAGE_TASK_KWARGS, "Offer Usage"),
+        (send_code_assignment_nudge_email, NUDGE_TASK_KWARGS, "Code Assignment Nudge Email"),
     )
     @ddt.unpack
     def test_client_instantiation_error(self, task, task_kwargs, logger_prefix):
@@ -749,6 +762,7 @@ class SendOfferEmailsTests(BaseSendEmailTests):
         (send_offer_assignment_email, ASSIGNMENT_TASK_KWARGS, "send", "Offer Assignment"),
         (send_offer_update_email, UPDATE_TASK_KWARGS, "send", "Offer Assignment"),
         (send_offer_usage_email, USAGE_TASK_KWARGS, "multi_send", "Offer Usage"),
+        (send_code_assignment_nudge_email, NUDGE_TASK_KWARGS, "send", "Code Assignment Nudge Email"),
     )
     @ddt.unpack
     def test_api_client_error(self, task, task_kwargs, mock_send, logger_prefix, mock_log):
@@ -768,6 +782,7 @@ class SendOfferEmailsTests(BaseSendEmailTests):
         (send_offer_assignment_email, ASSIGNMENT_TASK_KWARGS, "Offer Assignment"),
         (send_offer_update_email, UPDATE_TASK_KWARGS, "Offer Assignment"),
         (send_offer_usage_email, USAGE_TASK_KWARGS, "Offer Usage"),
+        (send_code_assignment_nudge_email, NUDGE_TASK_KWARGS, "Code Assignment Nudge Email"),
     )
     @ddt.unpack
     def test_api_error_with_retry(self, task, task_kwargs, logger_prefix):
@@ -809,6 +824,7 @@ class SendOfferEmailsTests(BaseSendEmailTests):
         (send_offer_assignment_email, ASSIGNMENT_TASK_KWARGS, "Offer Assignment"),
         (send_offer_update_email, UPDATE_TASK_KWARGS, "Offer Assignment"),
         (send_offer_usage_email, USAGE_TASK_KWARGS, "Offer Usage"),
+        (send_code_assignment_nudge_email, NUDGE_TASK_KWARGS, "Code Assignment Nudge Email"),
     )
     @ddt.unpack
     def test_api_error_without_retry(self, task, task_kwargs, logger_prefix):
@@ -850,6 +866,7 @@ class SendOfferEmailsTests(BaseSendEmailTests):
     @ddt.data(
         (send_offer_update_email, UPDATE_TASK_KWARGS, "Offer Assignment"),
         (send_offer_usage_email, USAGE_TASK_KWARGS, "Offer Usage"),
+        (send_code_assignment_nudge_email, NUDGE_TASK_KWARGS, "Code Assignment Nudge Email"),
     )
     @ddt.unpack
     def test_api(self, task, task_kwargs, logger_prefix):

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def is_requirement(line):
 
 setup(
     name='edx-ecommerce-worker',
-    version='0.9.0',
+    version='0.10.0',
     description='Celery tasks supporting the operations of edX\'s ecommerce service',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
…ils.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production
    - `test.in` for test requirements
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] [Version](https://github.com/edx/ecommerce-worker/blob/master/setup.py) bumped

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/ecommerce-worker/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/ecommerce-worker), verify version has been pushed to [PyPI](https://pypi.org/project/edx-ecommerce-worker/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [ecommerce](https://github.com/edx/ecommerce) to upgrade dependencies (including ecommerce-worker)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in ecommerce will look for the latest version in PyPi.
    - Note: the ecommerce-worker constraint in ecommerce **must** also be bumped to the latest version in PyPi.
- [ ] Deploy `ecommerce`
- [ ] Deploy `ecomworker` on GoCD.
    - While some functions in ecommerce-worker are run via ecommerce, others are handled by a standalone AMI and must be
      released via GoCD.
