### PR TITLE
[BTR-35] Update BROKER_URL default value

### DIFF
--- a/ecommerce_worker/configuration/base.py
+++ b/ecommerce_worker/configuration/base.py
@@ -1,6 +1,6 @@
 # CELERY
 # Default broker URL. See http://celery.readthedocs.org/en/latest/configuration.html#broker-url.
-BROKER_URL = 'amqp://celery:celery@127.0.0.1:5672'
+BROKER_URL = 'redis://:celery@127.0.0.1:6379'
 
 # Disable connection pooling. Connections may be severed by load balancers.
 # This forces the application to connect explicitly to the broker each time

--- a/ecommerce_worker/configuration/local.py
+++ b/ecommerce_worker/configuration/local.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 # CELERY
-BROKER_URL = 'amqp://'
+BROKER_URL = 'redis://'
 # END CELERY
 
 


### PR DESCRIPTION
This PR changes default value of `BROKER_URL` to expect Redis URL.

**JIRA tickets**:
- [BTR-35](https://openedx.atlassian.net/browse/BTR-35)

**Dependencies**:
- https://github.com/edx/configuration/pull/6189
