### PR TITLE
ENT3710 Add sender alias to use as from name in sailthru email templates

### DIFF
--- a/ecommerce_worker/sailthru/v1/tasks.py
+++ b/ecommerce_worker/sailthru/v1/tasks.py
@@ -362,7 +362,7 @@ def send_course_refund_email(self, email, refund_id, amount, course_name, order_
 
 
 @shared_task(bind=True, ignore_result=True)
-def send_offer_assignment_email(self, user_email, offer_assignment_id, subject, email_body,
+def send_offer_assignment_email(self, user_email, offer_assignment_id, subject, email_body, sender_alias,
                                 site_code=None, base_enterprise_url=''):
     """
     Sends the offer assignment email.
@@ -375,6 +375,7 @@ def send_offer_assignment_email(self, user_email, offer_assignment_id, subject, 
         email_body (str): The body of the email.
         site_code (str): Identifier of the site sending the email.
         base_enterprise_url (str): Url for the enterprise learner portal.
+        sender_alias (str): Enterprise Customer sender alias used as From Name.
     """
     config = get_sailthru_configuration(site_code)
     notification = Notification(
@@ -384,6 +385,7 @@ def send_offer_assignment_email(self, user_email, offer_assignment_id, subject, 
             'subject': subject,
             'email_body': email_body,
             'base_enterprise_url': base_enterprise_url,
+            'sender_alias': sender_alias,
         },
         logger_prefix='Offer Assignment',
         site_code=site_code,
@@ -442,7 +444,7 @@ def _update_assignment_email_status(offer_assignment_id, send_id, status, site_c
 
 
 @shared_task(bind=True, ignore_result=True)
-def send_offer_update_email(self, user_email, subject, email_body, site_code=None):
+def send_offer_update_email(self, user_email, subject, email_body, sender_alias, site_code=None):
     """
     Sends the offer emails after assignment, either for revoking or reminding.
 
@@ -452,6 +454,7 @@ def send_offer_update_email(self, user_email, subject, email_body, site_code=Non
         subject (str): Email subject.
         email_body (str): The body of the email.
         site_code (str): Identifier of the site sending the email.
+        sender_alias (str): Enterprise Customer sender alias used as From Name.
     """
     config = get_sailthru_configuration(site_code)
     notification = Notification(
@@ -459,7 +462,8 @@ def send_offer_update_email(self, user_email, subject, email_body, site_code=Non
         emails=user_email,
         email_vars={
             'subject': subject,
-            'email_body': email_body
+            'email_body': email_body,
+            'sender_alias': sender_alias,
         },
         logger_prefix='Offer Assignment',
         site_code=site_code,
@@ -517,7 +521,8 @@ def send_code_assignment_nudge_email(self, email, subject, email_body, site_code
         emails=email,
         email_vars={
             'subject': subject,
-            'email_body': email_body
+            'email_body': email_body,
+            'sender_alias': 'edX Support Team',
         },
         logger_prefix='Code Assignment Nudge Email',
         site_code=site_code,

--- a/ecommerce_worker/sailthru/v1/tests/test_tasks.py
+++ b/ecommerce_worker/sailthru/v1/tests/test_tasks.py
@@ -691,6 +691,7 @@ class SendOfferEmailsTests(BaseSendEmailTests):
     EMAIL_BODY = 'Template message with johndoe@unknown.com GIL7RUEOU7VHBH7Q ' \
                  'http://tempurl.url/enroll 3 2012-04-23'
     BASE_ENTERPRISE_URL = 'https://bears.party'
+    SENDER_ALIAS = 'edx Support Team'
 
     ASSIGNMENT_TASK_KWARGS = {
         'user_email': USER_EMAIL,
@@ -698,12 +699,14 @@ class SendOfferEmailsTests(BaseSendEmailTests):
         'subject': SUBJECT,
         'email_body': EMAIL_BODY,
         'base_enterprise_url': BASE_ENTERPRISE_URL,
+        'sender_alias': SENDER_ALIAS,
     }
 
     UPDATE_TASK_KWARGS = {
         'user_email': USER_EMAIL,
         'subject': SUBJECT,
         'email_body': EMAIL_BODY,
+        'sender_alias': SENDER_ALIAS,
     }
 
     USAGE_TASK_KWARGS = {

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def is_requirement(line):
 
 setup(
     name='edx-ecommerce-worker',
-    version='1.1.4',
+    version='1.1.5',
     description='Celery tasks supporting the operations of edX\'s ecommerce service',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
[ENT3710](https://openedx.atlassian.net/browse/ENT-3710): Add sender alias to use as from name in sailthru email templates
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production
    - `test.in` for test requirements
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] [Version](https://github.com/edx/ecommerce-worker/blob/master/setup.py) bumped

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/ecommerce-worker/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/ecommerce-worker), verify version has been pushed to [PyPI](https://pypi.org/project/edx-ecommerce-worker/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [ecommerce](https://github.com/edx/ecommerce) to upgrade dependencies (including ecommerce-worker)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in ecommerce will look for the latest version in PyPi.
    - Note: the ecommerce-worker constraint in ecommerce **must** also be bumped to the latest version in PyPi.
- [ ] Deploy `ecommerce`
- [ ] Deploy `ecomworker` on GoCD.
    - While some functions in ecommerce-worker are run via ecommerce, others are handled by a standalone AMI and must be
      released via GoCD.
