### PR TITLE
ENT-4070: Updated client for Braze to support hard-bounce api call

### DIFF
--- a/ecommerce_worker/configuration/base.py
+++ b/ecommerce_worker/configuration/base.py
@@ -78,6 +78,7 @@ BRAZE = {
     'BRAZE_WEBAPP_API_KEY': None,
     'REST_API_URL': 'https://rest.iad-06.braze.com',
     'MESSAGES_SEND_ENDPOINT': '/messages/send',
+    'EMAIL_BOUNCE_ENDPOINT': '/email/hard_bounces',
     'FROM_EMAIL': '<edx-for-business-no-reply@info.edx.org>',
     # Retry settings for Braze celery tasks
     'BRAZE_RETRY_SECONDS': 3600,

--- a/ecommerce_worker/sailthru/v1/tasks.py
+++ b/ecommerce_worker/sailthru/v1/tasks.py
@@ -379,8 +379,9 @@ def _send_offer_assignment_email_via_braze(self, user_email, offer_assignment_id
         sender_alias (str): Enterprise Customer sender alias used as From Name.
     """
     config = get_braze_configuration(site_code)
+    endpoint = config.get('MESSAGES_SEND_ENDPOINT')
     try:
-        braze_client = get_braze_client(site_code)
+        braze_client = get_braze_client(site_code, endpoint)
         response = braze_client.send_message(
             email_ids=list(user_email),
             subject=subject,
@@ -531,8 +532,9 @@ def _send_offer_update_email_via_braze(self, user_email, subject, email_body, se
         sender_alias (str): Enterprise Customer sender alias used as From Name.
     """
     config = get_braze_configuration(site_code)
+    endpoint = config.get('MESSAGES_SEND_ENDPOINT')
     try:
-        braze_client = get_braze_client(site_code)
+        braze_client = get_braze_client(site_code, endpoint)
         braze_client.send_message(
             email_ids=list(user_email),
             subject=subject,
@@ -612,8 +614,9 @@ def _send_offer_usage_email_via_braze(self, emails, subject, email_body, site_co
         site_code (str): Identifier of the site sending the email.
     """
     config = get_braze_configuration(site_code)
+    endpoint = config.get('MESSAGES_SEND_ENDPOINT')
     try:
-        braze_client = get_braze_client(site_code)
+        braze_client = get_braze_client(site_code, endpoint)
         braze_client.send_message(
             email_ids=list(emails),
             subject=subject,
@@ -689,8 +692,9 @@ def _send_code_assignment_nudge_email_via_braze(self, email, subject, email_body
         site_code (str): Identifier of the site sending the email.
     """
     config = get_braze_configuration(site_code)
+    endpoint = config.get('MESSAGES_SEND_ENDPOINT')
     try:
-        braze_client = get_braze_client(site_code)
+        braze_client = get_braze_client(site_code, endpoint)
         braze_client.send_message(
             email_ids=list(email),
             subject=subject,

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def is_requirement(line):
 
 setup(
     name='edx-ecommerce-worker',
-    version='1.1.7',
+    version='1.1.8',
     description='Celery tasks supporting the operations of edX\'s ecommerce service',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production
    - `test.in` for test requirements
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] [Version](https://github.com/edx/ecommerce-worker/blob/master/setup.py) bumped

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/ecommerce-worker/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/ecommerce-worker), verify version has been pushed to [PyPI](https://pypi.org/project/edx-ecommerce-worker/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [ecommerce](https://github.com/edx/ecommerce) to upgrade dependencies (including ecommerce-worker)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in ecommerce will look for the latest version in PyPi.
    - Note: the ecommerce-worker constraint in ecommerce **must** also be bumped to the latest version in PyPi.
- [ ] Deploy `ecommerce`
- [ ] Deploy `ecomworker` on GoCD.
    - While some functions in ecommerce-worker are run via ecommerce, others are handled by a standalone AMI and must be
      released via GoCD.
