### PR TITLE
ENT-3988: Update nudge email task to include sender_alias

### DIFF
--- a/ecommerce_worker/sailthru/v1/tasks.py
+++ b/ecommerce_worker/sailthru/v1/tasks.py
@@ -677,7 +677,7 @@ def send_offer_usage_email(self, emails, subject, email_body, site_code=None):
         _send_offer_usage_email_via_sailthru(self, emails, subject, email_body, site_code)
 
 
-def _send_code_assignment_nudge_email_via_braze(self, email, subject, email_body, site_code=None):
+def _send_code_assignment_nudge_email_via_braze(self, email, subject, email_body, sender_alias, site_code=None):
     """
     Sends the code assignment nudge email via braze.
 
@@ -686,6 +686,7 @@ def _send_code_assignment_nudge_email_via_braze(self, email, subject, email_body
         email (str): Recipient's email address.
         subject (str): Email subject.
         email_body (str): The body of the email.
+        sender_alias (str): Enterprise Customer sender alias used as From Name.
         site_code (str): Identifier of the site sending the email.
     """
     config = get_braze_configuration(site_code)
@@ -695,6 +696,7 @@ def _send_code_assignment_nudge_email_via_braze(self, email, subject, email_body
             email_ids=list(email),
             subject=subject,
             body=email_body,
+            sender_alias=sender_alias
         )
     except (BrazeRateLimitError, BrazeInternalServerError):
         raise self.retry(countdown=config.get('BRAZE_RETRY_SECONDS'),
@@ -706,7 +708,7 @@ def _send_code_assignment_nudge_email_via_braze(self, email, subject, email_body
         )
 
 
-def _send_code_assignment_nudge_email_via_sailthru(self, email, subject, email_body, site_code=None):
+def _send_code_assignment_nudge_email_via_sailthru(self, email, subject, email_body, sender_alias, site_code=None):
     """
     Sends the code assignment nudge email via sailthru.
 
@@ -715,6 +717,7 @@ def _send_code_assignment_nudge_email_via_sailthru(self, email, subject, email_b
         email (str): Recipient's email address.
         subject (str): Email subject.
         email_body (str): The body of the email.
+        sender_alias (str): Enterprise Customer sender alias used as From Name.
         site_code (str): Identifier of the site sending the email.
     """
     config = get_sailthru_configuration(site_code)
@@ -724,7 +727,7 @@ def _send_code_assignment_nudge_email_via_sailthru(self, email, subject, email_b
         email_vars={
             'subject': subject,
             'email_body': email_body,
-            'sender_alias': 'edX Support Team',
+            'sender_alias': sender_alias,
         },
         logger_prefix='Code Assignment Nudge Email',
         site_code=site_code,
@@ -736,7 +739,7 @@ def _send_code_assignment_nudge_email_via_sailthru(self, email, subject, email_b
 
 
 @shared_task(bind=True, ignore_result=True)
-def send_code_assignment_nudge_email(self, email, subject, email_body, site_code=None):
+def send_code_assignment_nudge_email(self, email, subject, email_body, sender_alias, site_code=None):
     """
     Sends the code assignment nudge email.
 
@@ -745,11 +748,12 @@ def send_code_assignment_nudge_email(self, email, subject, email_body, site_code
         email (str): Recipient's email address.
         subject (str): Email subject.
         email_body (str): The body of the email.
+        sender_alias (str): Enterprise Customer sender alias used as From Name.
         site_code (str): Identifier of the site sending the email.
     """
     config = get_braze_configuration(site_code)
     braze_enable = config.get('BRAZE_ENABLE')
     if braze_enable:
-        _send_code_assignment_nudge_email_via_braze(self, email, subject, email_body, site_code)
+        _send_code_assignment_nudge_email_via_braze(self, email, subject, email_body, sender_alias, site_code)
     else:
-        _send_code_assignment_nudge_email_via_sailthru(self, email, subject, email_body, site_code)
+        _send_code_assignment_nudge_email_via_sailthru(self, email, subject, email_body, sender_alias, site_code)

--- a/ecommerce_worker/sailthru/v1/tests/test_tasks.py
+++ b/ecommerce_worker/sailthru/v1/tests/test_tasks.py
@@ -726,6 +726,7 @@ class SendOfferEmailsTests(BaseSendEmailTests):
         'email': USER_EMAIL,
         'subject': SUBJECT,
         'email_body': EMAIL_BODY,
+        'sender_alias': SENDER_ALIAS,
     }
 
     def execute_task(self):
@@ -1061,6 +1062,7 @@ class SendOfferEmailsTestsWithBraze(TestCase):
         'email': USER_EMAIL,
         'subject': SUBJECT,
         'email_body': EMAIL_BODY,
+        'sender_alias': SENDER_ALIAS,
         'site_code': 'test'
     }
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def is_requirement(line):
 
 setup(
     name='edx-ecommerce-worker',
-    version='1.1.9',
+    version='1.1.10',
     description='Celery tasks supporting the operations of edX\'s ecommerce service',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production
    - `test.in` for test requirements
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] [Version](https://github.com/edx/ecommerce-worker/blob/master/setup.py) bumped

**Post merge:**
- [x] Tag pushed and a new [version](https://github.com/edx/ecommerce-worker/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [x] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/ecommerce-worker), verify version has been pushed to [PyPI](https://pypi.org/project/edx-ecommerce-worker/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [x] PR created in [ecommerce](https://github.com/edx/ecommerce) to upgrade dependencies (including ecommerce-worker)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in ecommerce will look for the latest version in PyPi.
    - Note: the ecommerce-worker constraint in ecommerce **must** also be bumped to the latest version in PyPi.
- [ ] Deploy `ecommerce`
- [x] Deploy `ecomworker` on GoCD.
    - While some functions in ecommerce-worker are run via ecommerce, others are handled by a standalone AMI and must be
      released via GoCD.
