### PR TITLE
fix: :bug: correct name for base_enterprise_url template var ENT-4396

### DIFF
--- a/ecommerce_worker/sailthru/v1/constants.py
+++ b/ecommerce_worker/sailthru/v1/constants.py
@@ -1,0 +1,1 @@
+BASE_ENTERPRISE_URL_VAR_NAME='base_enterprise_url'

--- a/ecommerce_worker/sailthru/v1/tasks.py
+++ b/ecommerce_worker/sailthru/v1/tasks.py
@@ -17,6 +17,7 @@ from ecommerce_worker.braze.v1.client import get_braze_client, get_braze_configu
 from ecommerce_worker.braze.v1.exceptions import BrazeError, BrazeRateLimitError, BrazeInternalServerError
 from ecommerce_worker.sailthru.v1.exceptions import SailthruError
 from ecommerce_worker.sailthru.v1.notification import Notification
+from ecommerce_worker.sailthru.v1.constants import BASE_ENTERPRISE_URL_VAR_NAME
 from ecommerce_worker.sailthru.v1.utils import (
     can_retry_sailthru_request,
     get_sailthru_client,
@@ -292,7 +293,7 @@ def _send_offer_assignment_email_via_sailthru(self, user_email, offer_assignment
         email_vars={
             'subject': subject,
             'email_body': email_body,
-            'base_enterprise_url': base_enterprise_url,
+            BASE_ENTERPRISE_URL_VAR_NAME: base_enterprise_url,
             'sender_alias': sender_alias,
         },
         logger_prefix='Offer Assignment',
@@ -436,7 +437,7 @@ def _send_offer_update_email_via_sailthru(self, user_email, subject, email_body,
             'subject': subject,
             'email_body': email_body,
             'sender_alias': sender_alias,
-            'base_enterprise_url': base_enterprise_url
+            BASE_ENTERPRISE_URL_VAR_NAME: base_enterprise_url
         },
         logger_prefix='Offer Assignment',
         site_code=site_code,
@@ -525,7 +526,7 @@ def _send_offer_usage_email_via_sailthru(self, emails, subject, email_body, site
         email_vars={
             'subject': subject,
             'email_body': email_body,
-            'base_enteprise_url': base_enterprise_url
+            BASE_ENTERPRISE_URL_VAR_NAME: base_enterprise_url
         },
         logger_prefix='Offer Usage',
         site_code=site_code,
@@ -617,7 +618,7 @@ def _send_code_assignment_nudge_email_via_sailthru(self, email, subject, email_b
             'subject': subject,
             'email_body': email_body,
             'sender_alias': sender_alias,
-            'base_enteprise_url': base_enterprise_url,
+            BASE_ENTERPRISE_URL_VAR_NAME: base_enterprise_url,
         },
         logger_prefix='Code Assignment Nudge Email',
         site_code=site_code,

--- a/ecommerce_worker/sailthru/v1/tests/test_tasks.py
+++ b/ecommerce_worker/sailthru/v1/tests/test_tasks.py
@@ -32,6 +32,7 @@ from ecommerce_worker.sailthru.v1.tasks import (
     send_offer_update_email,
     send_offer_usage_email,
 )
+from ecommerce_worker.sailthru.v1.constants import BASE_ENTERPRISE_URL_VAR_NAME
 from ecommerce_worker.utils import get_configuration
 
 TEST_EMAIL = "test@edx.org"
@@ -294,7 +295,7 @@ class SendOfferEmailsTests(BaseSendEmailTests):
         'offer_assignment_id': OFFER_ASSIGNMENT_ID,
         'subject': SUBJECT,
         'email_body': EMAIL_BODY,
-        'base_enterprise_url': BASE_ENTERPRISE_URL,
+        BASE_ENTERPRISE_URL_VAR_NAME: BASE_ENTERPRISE_URL,
         'sender_alias': SENDER_ALIAS,
     }
 
@@ -302,14 +303,14 @@ class SendOfferEmailsTests(BaseSendEmailTests):
         'user_email': USER_EMAIL,
         'subject': SUBJECT,
         'email_body': EMAIL_BODY,
-        'base_enterprise_url': BASE_ENTERPRISE_URL,
+        BASE_ENTERPRISE_URL_VAR_NAME: BASE_ENTERPRISE_URL,
         'sender_alias': SENDER_ALIAS,
     }
 
     USAGE_TASK_KWARGS = {
         'emails': EMAILS,
         'subject': SUBJECT,
-        'base_enterprise_url': BASE_ENTERPRISE_URL,
+        BASE_ENTERPRISE_URL_VAR_NAME: BASE_ENTERPRISE_URL,
         'email_body': EMAIL_BODY,
     }
 
@@ -317,7 +318,7 @@ class SendOfferEmailsTests(BaseSendEmailTests):
         'email': USER_EMAIL,
         'subject': SUBJECT,
         'email_body': EMAIL_BODY,
-        'base_enterprise_url': BASE_ENTERPRISE_URL,
+        BASE_ENTERPRISE_URL_VAR_NAME: BASE_ENTERPRISE_URL,
         'sender_alias': SENDER_ALIAS,
     }
 
@@ -633,7 +634,7 @@ class SendOfferEmailsTestsWithBraze(TestCase):
         'offer_assignment_id': OFFER_ASSIGNMENT_ID,
         'subject': SUBJECT,
         'email_body': EMAIL_BODY,
-        'base_enterprise_url': BASE_ENTERPRISE_URL,
+        BASE_ENTERPRISE_URL_VAR_NAME: BASE_ENTERPRISE_URL,
         'sender_alias': SENDER_ALIAS,
         'site_code': 'test'
     }

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def is_requirement(line):
 
 setup(
     name='edx-ecommerce-worker',
-    version='1.2.0',
+    version='1.2.1',
     description='Celery tasks supporting the operations of edX\'s ecommerce service',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
We were passing incorrect name for base_enterprise_url, used to be 'base_enteprise_url`

this led to emails for Offer assignment, and Offer nudge (reminder) both to contain the default incorrect link in the button rendered in the email, that says 'Find a course'

This fix uses a constant to represent the var name for only this variable (but it could be extended to other vars, I did not opt to do it to really scope down the bug fix for this PR, reviewers can convince me otherwise!)

### Testing notes

I did not go the extra mile here to add a test, or to verify locally since it seems this is testable in staging

I do not yet know if I know how to test ecommerce-worker changes in staging, reading up more

but current plan is to test via a sailthru template in staging, once this change is in staging

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production
    - `test.in` for test requirements
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] [Version](https://github.com/edx/ecommerce-worker/blob/master/setup.py) bumped

**Post merge:**
- [x] Tag pushed and a new [version](https://github.com/edx/ecommerce-worker/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/ecommerce-worker), verify version has been pushed to [PyPI](https://pypi.org/project/edx-ecommerce-worker/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [ecommerce](https://github.com/edx/ecommerce) to upgrade dependencies (including ecommerce-worker)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in ecommerce will look for the latest version in PyPi.
    - Note: the ecommerce-worker constraint in ecommerce **must** also be bumped to the latest version in PyPi.
- [ ] Deploy `ecommerce`
- [ ] Deploy `ecomworker` on GoCD.
    - While some functions in ecommerce-worker are run via ecommerce, others are handled by a standalone AMI and must be
      released via GoCD.
