### PR TITLE
ENT-4195: Logging for braze POST request

### DIFF
--- a/ecommerce_worker/braze/v1/client.py
+++ b/ecommerce_worker/braze/v1/client.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import
 
+import copy
 import json
 import requests
 
@@ -351,6 +352,14 @@ class BrazeClient(object):
                 'email': email
             }
         }
+        # Scrub the app_id from the log message
+        cleaned_message = copy.copy(message)
+        cleaned_app_id = '{}...{}'.format(cleaned_message['messages']['email']['app_id'][0:4],
+                                          cleaned_message['messages']['email']['app_id'][-4:])
+        cleaned_message['messages']['email']['app_id'] = cleaned_app_id
+        log.info(
+            '[ECOMM-WORKER-BRAZE] Message: [%s], URL: [%s]', str(cleaned_message), str(self.messages_send_endpoint)
+        )
         return self.__create_post_request(message, self.messages_send_endpoint)
 
     def did_email_bounce(

--- a/ecommerce_worker/sailthru/v1/tests/test_tasks.py
+++ b/ecommerce_worker/sailthru/v1/tests/test_tasks.py
@@ -860,7 +860,7 @@ class SendOfferEmailsTestsWithBraze(TestCase):
             status=201)
         with LogCapture(level=logging.INFO) as log:
             self.execute_task()
-        log.check(
+        log.check_present(
             (
                 self.LOG_TASK_NAME,
                 'INFO',
@@ -890,7 +890,7 @@ class SendOfferEmailsTestsWithBraze(TestCase):
         mock_get_ecommerce_client.side_effect = RequestException
         with LogCapture(level=logging.INFO) as log:
             self.execute_task()
-        log.check(
+        log.check_present(
             (
                 self.LOG_TASK_NAME,
                 'ERROR',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def is_requirement(line):
 
 setup(
     name='edx-ecommerce-worker',
-    version='1.3.0',
+    version='1.3.1',
     description='Celery tasks supporting the operations of edX\'s ecommerce service',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production
    - `test.in` for test requirements
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] [Version](https://github.com/edx/ecommerce-worker/blob/master/setup.py) bumped

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/ecommerce-worker/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/ecommerce-worker), verify version has been pushed to [PyPI](https://pypi.org/project/edx-ecommerce-worker/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [ecommerce](https://github.com/edx/ecommerce) to upgrade dependencies (including ecommerce-worker)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in ecommerce will look for the latest version in PyPi.
    - Note: the ecommerce-worker constraint in ecommerce **must** also be bumped to the latest version in PyPi.
- [ ] Deploy `ecommerce`
- [ ] Deploy `ecomworker` on GoCD.
    - While some functions in ecommerce-worker are run via ecommerce, others are handled by a standalone AMI and must be
      released via GoCD.
