### PR TITLE
ENT-4195: Added guard for empty data and fixed api key

### DIFF
--- a/ecommerce_worker/braze/v1/client.py
+++ b/ecommerce_worker/braze/v1/client.py
@@ -278,12 +278,14 @@ class BrazeClient(object):
         alias_message = {
             'user_aliases': user_aliases,
         }
-        self.__create_post_request(alias_message, self.new_alias_endpoint)
+        if user_aliases:
+            self.__create_post_request(alias_message, self.new_alias_endpoint)
 
         attribute_message = {
             'attributes': attributes
         }
-        self.__create_post_request(attribute_message, self.users_track_endpoint)
+        if attributes:
+            self.__create_post_request(attribute_message, self.users_track_endpoint)
 
     def send_message(
         self,
@@ -353,7 +355,7 @@ class BrazeClient(object):
             }
         }
         # Scrub the app_id from the log message
-        cleaned_message = copy.copy(message)
+        cleaned_message = copy.deepcopy(message)
         cleaned_app_id = '{}...{}'.format(cleaned_message['messages']['email']['app_id'][0:4],
                                           cleaned_message['messages']['email']['app_id'][-4:])
         cleaned_message['messages']['email']['app_id'] = cleaned_app_id

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def is_requirement(line):
 
 setup(
     name='edx-ecommerce-worker',
-    version='1.3.1',
+    version='1.3.2',
     description='Celery tasks supporting the operations of edX\'s ecommerce service',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production
    - `test.in` for test requirements
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] [Version](https://github.com/edx/ecommerce-worker/blob/master/setup.py) bumped

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/ecommerce-worker/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/ecommerce-worker), verify version has been pushed to [PyPI](https://pypi.org/project/edx-ecommerce-worker/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [ecommerce](https://github.com/edx/ecommerce) to upgrade dependencies (including ecommerce-worker)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in ecommerce will look for the latest version in PyPi.
    - Note: the ecommerce-worker constraint in ecommerce **must** also be bumped to the latest version in PyPi.
- [ ] Deploy `ecommerce`
- [ ] Deploy `ecomworker` on GoCD.
    - While some functions in ecommerce-worker are run via ecommerce, others are handled by a standalone AMI and must be
      released via GoCD.
