### PR TITLE
ENT-4252: Added reply_to option for braze messages

### DIFF
--- a/ecommerce_worker/email/v1/braze/client.py
+++ b/ecommerce_worker/email/v1/braze/client.py
@@ -294,7 +294,8 @@ class BrazeClient(object):
         email_ids,
         subject,
         body,
-        sender_alias='EdX Support Team'
+        sender_alias='EdX Support Team',
+        reply_to='',
     ):
         """
         Sends the message via Braze Rest API /messages/send
@@ -304,6 +305,7 @@ class BrazeClient(object):
             subject (str): e.g. 'Test Subject'
             body (str): e.g. '<html>Test Html Message</html>'
             sender_alias (str): sender alias for email e.g. edX Support Team
+            reply_to (str): Enterprise Customer reply to address for email reply
 
         Request message format:
             Content-Type: application/json
@@ -316,6 +318,7 @@ class BrazeClient(object):
                             "app_id": "99999999-9999-9999-9999-999999999999",
                             "subject": "Testing",
                             "from": "edX <edx-for-business-no-reply@info.edx.org>",
+                            "reply_to": "reply@edx.org",
                             "body": "<html>Test</html>"
                         }
                     }
@@ -349,6 +352,8 @@ class BrazeClient(object):
             'from': sender_alias + self.from_email,
             'body': body,
         }
+        if reply_to:
+            email['reply_to'] = reply_to
         message = {
             'user_aliases': user_aliases,
             'external_user_ids': external_ids,

--- a/ecommerce_worker/email/v1/braze/tasks.py
+++ b/ecommerce_worker/email/v1/braze/tasks.py
@@ -12,7 +12,7 @@ logger = get_task_logger(__name__)
 
 
 def send_offer_assignment_email_via_braze(self, user_email, offer_assignment_id, subject, email_body, sender_alias,
-                                          site_code):
+                                          reply_to, site_code):
     """
     Sends the offer assignment email via Braze.
 
@@ -23,6 +23,7 @@ def send_offer_assignment_email_via_braze(self, user_email, offer_assignment_id,
         subject (str): Email subject.
         email_body (str): The body of the email.
         sender_alias (str): Enterprise Customer sender alias used as From Name.
+        reply_to (str): Enterprise Customer reply to address for email reply
         site_code (str): Identifier of the site sending the email.
         base_enterprise_url (str): Url for the enterprise learner portal.
     """
@@ -34,7 +35,8 @@ def send_offer_assignment_email_via_braze(self, user_email, offer_assignment_id,
             email_ids=user_emails,
             subject=subject,
             body=email_body,
-            sender_alias=sender_alias
+            sender_alias=sender_alias,
+            reply_to=reply_to
         )
         if response and response['success']:
             dispatch_id = response['dispatch_id']
@@ -60,7 +62,7 @@ def send_offer_assignment_email_via_braze(self, user_email, offer_assignment_id,
         )
 
 
-def send_offer_update_email_via_braze(self, user_email, subject, email_body, sender_alias, site_code):
+def send_offer_update_email_via_braze(self, user_email, subject, email_body, sender_alias, reply_to, site_code):
     """
     Sends the offer emails after assignment via braze, either for revoking or reminding.
 
@@ -71,6 +73,7 @@ def send_offer_update_email_via_braze(self, user_email, subject, email_body, sen
         email_body (str): The body of the email.
         site_code (str): Identifier of the site sending the email.
         sender_alias (str): Enterprise Customer sender alias used as From Name.
+        reply_to (str): Enterprise Customer reply to address for email reply
     """
     config = get_braze_configuration(site_code)
     try:
@@ -80,7 +83,8 @@ def send_offer_update_email_via_braze(self, user_email, subject, email_body, sen
             email_ids=user_emails,
             subject=subject,
             body=email_body,
-            sender_alias=sender_alias
+            sender_alias=sender_alias,
+            reply_to=reply_to
         )
     except (BrazeRateLimitError, BrazeInternalServerError):
         raise self.retry(countdown=config.get('BRAZE_RETRY_SECONDS'),
@@ -92,7 +96,7 @@ def send_offer_update_email_via_braze(self, user_email, subject, email_body, sen
         )
 
 
-def send_offer_usage_email_via_braze(self, emails, subject, email_body, site_code):
+def send_offer_usage_email_via_braze(self, emails, subject, email_body, reply_to, site_code):
     """
     Sends the offer usage email via braze.
 
@@ -101,6 +105,7 @@ def send_offer_usage_email_via_braze(self, emails, subject, email_body, site_cod
         emails (str): comma separated emails.
         subject (str): Email subject.
         email_body (str): The body of the email.
+        reply_to (str): Enterprise Customer reply to address for email reply
         site_code (str): Identifier of the site sending the email.
     """
     config = get_braze_configuration(site_code)
@@ -110,7 +115,8 @@ def send_offer_usage_email_via_braze(self, emails, subject, email_body, site_cod
         braze_client.send_message(
             email_ids=user_emails,
             subject=subject,
-            body=email_body
+            body=email_body,
+            reply_to=reply_to
         )
     except (BrazeRateLimitError, BrazeInternalServerError):
         raise self.retry(countdown=config.get('BRAZE_RETRY_SECONDS'),

--- a/ecommerce_worker/email/v1/braze/tasks.py
+++ b/ecommerce_worker/email/v1/braze/tasks.py
@@ -122,7 +122,7 @@ def send_offer_usage_email_via_braze(self, emails, subject, email_body, site_cod
         )
 
 
-def send_code_assignment_nudge_email_via_braze(self, email, subject, email_body, sender_alias, site_code):
+def send_code_assignment_nudge_email_via_braze(self, email, subject, email_body, sender_alias, reply_to, site_code):
     """
     Sends the code assignment nudge email via braze.
 
@@ -132,6 +132,7 @@ def send_code_assignment_nudge_email_via_braze(self, email, subject, email_body,
         subject (str): Email subject.
         email_body (str): The body of the email.
         sender_alias (str): Enterprise Customer sender alias used as From Name.
+        reply_to (str): Enterprise Customer reply to address for email reply
         site_code (str): Identifier of the site sending the email.
     """
     config = get_braze_configuration(site_code)
@@ -142,7 +143,8 @@ def send_code_assignment_nudge_email_via_braze(self, email, subject, email_body,
             email_ids=user_emails,
             subject=subject,
             body=email_body,
-            sender_alias=sender_alias
+            sender_alias=sender_alias,
+            reply_to=reply_to,
         )
     except (BrazeRateLimitError, BrazeInternalServerError):
         raise self.retry(countdown=config.get('BRAZE_RETRY_SECONDS'),

--- a/ecommerce_worker/email/v1/braze/tests/test_tasks.py
+++ b/ecommerce_worker/email/v1/braze/tests/test_tasks.py
@@ -36,7 +36,7 @@ class SendEmailsViaBrazeTests(TestCase):
     EMAIL_BODY = 'Template message with johndoe@unknown.com GIL7RUEOU7VHBH7Q ' \
                  'https://tempurl.url/enroll 3 2012-04-23'
     SENDER_ALIAS = 'edx Support Team'
-    REPLY_TO = 'no-reply@edx.org'
+    REPLY_TO = 'reply@edx.org'
     SITE_CODE = 'test'
     BRAZE_CONFIG = {
         'BRAZE_ENABLE': True,
@@ -61,6 +61,7 @@ class SendEmailsViaBrazeTests(TestCase):
         'subject': SUBJECT,
         'email_body': EMAIL_BODY,
         'sender_alias': SENDER_ALIAS,
+        'reply_to': REPLY_TO,
         'site_code': SITE_CODE,
     }
 
@@ -69,6 +70,7 @@ class SendEmailsViaBrazeTests(TestCase):
         'subject': SUBJECT,
         'email_body': EMAIL_BODY,
         'sender_alias': SENDER_ALIAS,
+        'reply_to': REPLY_TO,
         'site_code': SITE_CODE,
     }
 
@@ -76,6 +78,7 @@ class SendEmailsViaBrazeTests(TestCase):
         'emails': EMAILS,
         'subject': SUBJECT,
         'email_body': EMAIL_BODY,
+        'reply_to': REPLY_TO,
         'site_code': SITE_CODE,
     }
 

--- a/ecommerce_worker/email/v1/braze/tests/test_tasks.py
+++ b/ecommerce_worker/email/v1/braze/tests/test_tasks.py
@@ -36,6 +36,7 @@ class SendEmailsViaBrazeTests(TestCase):
     EMAIL_BODY = 'Template message with johndoe@unknown.com GIL7RUEOU7VHBH7Q ' \
                  'https://tempurl.url/enroll 3 2012-04-23'
     SENDER_ALIAS = 'edx Support Team'
+    REPLY_TO = 'no-reply@edx.org'
     SITE_CODE = 'test'
     BRAZE_CONFIG = {
         'BRAZE_ENABLE': True,
@@ -83,6 +84,7 @@ class SendEmailsViaBrazeTests(TestCase):
         'subject': SUBJECT,
         'email_body': EMAIL_BODY,
         'sender_alias': SENDER_ALIAS,
+        'reply_to': REPLY_TO,
         'site_code': SITE_CODE,
     }
 

--- a/ecommerce_worker/email/v1/tasks.py
+++ b/ecommerce_worker/email/v1/tasks.py
@@ -20,7 +20,7 @@ from ecommerce_worker.email.v1.braze.tasks import (
 
 @shared_task(bind=True, ignore_result=True)
 def send_offer_assignment_email(self, user_email, offer_assignment_id, subject, email_body, sender_alias,
-                                site_code=None, base_enterprise_url='') -> None:
+                                reply_to='', site_code=None, base_enterprise_url='') -> None:
     """
     Sends the offer assignment email.
 
@@ -33,14 +33,15 @@ def send_offer_assignment_email(self, user_email, offer_assignment_id, subject, 
         site_code (str): Identifier of the site sending the email.
         base_enterprise_url (str): Url for the enterprise learner portal.
         sender_alias (str): Enterprise Customer sender alias used as From Name.
+        reply_to (str): Enterprise Customer reply to address for email reply
     """
     if is_braze_enabled(site_code):
         send_offer_assignment_email_via_braze(
-            self, user_email, offer_assignment_id, subject, email_body, sender_alias, site_code)
+            self, user_email, offer_assignment_id, subject, email_body, sender_alias, reply_to, site_code)
 
 
 @shared_task(bind=True, ignore_result=True)
-def send_offer_update_email(self, user_email, subject, email_body, sender_alias, site_code=None,
+def send_offer_update_email(self, user_email, subject, email_body, sender_alias, reply_to='', site_code=None,
                             base_enterprise_url='') -> None:
     """
     Sends the offer emails after assignment, either for revoking or reminding.
@@ -52,14 +53,15 @@ def send_offer_update_email(self, user_email, subject, email_body, sender_alias,
         email_body (str): The body of the email.
         site_code (str): Identifier of the site sending the email.
         sender_alias (str): Enterprise Customer sender alias used as From Name.
+        reply_to (str): Enterprise Customer reply to address for email reply
         base_enterprise_url (str): Enterprise learner portal url.
     """
     if is_braze_enabled(site_code):
-        send_offer_update_email_via_braze(self, user_email, subject, email_body, sender_alias, site_code)
+        send_offer_update_email_via_braze(self, user_email, subject, email_body, sender_alias, reply_to, site_code)
 
 
 @shared_task(bind=True, ignore_result=True)
-def send_offer_usage_email(self, emails, subject, email_body, site_code=None,
+def send_offer_usage_email(self, emails, subject, email_body, reply_to='', site_code=None,
                            base_enterprise_url='') -> None:
     """
     Sends the offer usage email.
@@ -69,11 +71,12 @@ def send_offer_usage_email(self, emails, subject, email_body, site_code=None,
         emails (str): comma separated emails.
         subject (str): Email subject.
         email_body (str): The body of the email.
+        reply_to (str): Enterprise Customer reply to address for email reply
         site_code (str): Identifier of the site sending the email.
         base_enterprise_url (str): Url of the enterprise's learner portal
     """
     if is_braze_enabled(site_code):
-        send_offer_usage_email_via_braze(self, emails, subject, email_body, site_code)
+        send_offer_usage_email_via_braze(self, emails, subject, email_body, reply_to, site_code)
 
 
 @shared_task(bind=True, ignore_result=True)

--- a/ecommerce_worker/email/v1/tasks.py
+++ b/ecommerce_worker/email/v1/tasks.py
@@ -77,7 +77,7 @@ def send_offer_usage_email(self, emails, subject, email_body, site_code=None,
 
 
 @shared_task(bind=True, ignore_result=True)
-def send_code_assignment_nudge_email(self, email, subject, email_body, sender_alias, site_code=None,
+def send_code_assignment_nudge_email(self, email, subject, email_body, sender_alias, reply_to='', site_code=None,
                                      base_enterprise_url='') -> None:
     """
     Sends the code assignment nudge email.
@@ -88,8 +88,9 @@ def send_code_assignment_nudge_email(self, email, subject, email_body, sender_al
         subject (str): Email subject.
         email_body (str): The body of the email.
         sender_alias (str): Enterprise Customer sender alias used as From Name.
+        reply_to (str): Enterprise Customer reply to address for email reply
         site_code (str): Identifier of the site sending the email.
         base_enterprise_url (str): Enterprise learner portal url.
     """
     if is_braze_enabled(site_code):
-        send_code_assignment_nudge_email_via_braze(self, email, subject, email_body, sender_alias, site_code)
+        send_code_assignment_nudge_email_via_braze(self, email, subject, email_body, sender_alias, reply_to, site_code)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def is_requirement(line):
 
 setup(
     name='edx-ecommerce-worker',
-    version='2.0.1',
+    version='2.1.0',
     description='Celery tasks supporting the operations of edX\'s ecommerce service',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production
    - `test.in` for test requirements
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] [Version](https://github.com/edx/ecommerce-worker/blob/master/setup.py) bumped

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/ecommerce-worker/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [Travis](https://travis-ci.org/github/edx/ecommerce-worker), verify version has been pushed to [PyPI](https://pypi.org/project/edx-ecommerce-worker/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [ecommerce](https://github.com/edx/ecommerce) to upgrade dependencies (including ecommerce-worker)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in ecommerce will look for the latest version in PyPi.
    - Note: the ecommerce-worker constraint in ecommerce **must** also be bumped to the latest version in PyPi.
- [ ] Deploy `ecommerce`
- [ ] Deploy `ecomworker` on GoCD.
    - While some functions in ecommerce-worker are run via ecommerce, others are handled by a standalone AMI and must be
      released via GoCD.
