### PR TITLE
Revert "feat: Include a Braze campaign id in code/offer emails."

### DIFF
--- a/ecommerce_worker/configuration/base.py
+++ b/ecommerce_worker/configuration/base.py
@@ -85,10 +85,6 @@ BRAZE = {
     'CAMPAIGN_SEND_ENDPOINT': '/campaigns/trigger/send',
     'FROM_EMAIL': '<edx-for-business-no-reply@info.edx.org>',
     'ENTERPRISE_CAMPAIGN_ID': '',
-    'ENTERPRISE_CODE_ASSIGNMENT_CAMPAIGN_ID': '',
-    'ENTERPRISE_CODE_UPDATE_CAMPAIGN_ID': '',
-    'ENTERPRISE_CODE_USAGE_CAMPAIGN_ID': '',
-    'ENTERPRISE_CODE_NUDGE_CAMPAIGN_ID': '',
     # Retry settings for Braze celery tasks
     'BRAZE_RETRY_SECONDS': 3600,
     'BRAZE_RETRY_ATTEMPTS': 6,

--- a/ecommerce_worker/email/v1/braze/client.py
+++ b/ecommerce_worker/email/v1/braze/client.py
@@ -295,7 +295,6 @@ class BrazeClient:
         sender_alias='EdX Support Team',
         reply_to='',
         attachments=[],
-        campaign_id='',
     ):
         """
         Sends the message via Braze Rest API /messages/send
@@ -307,7 +306,6 @@ class BrazeClient:
             sender_alias (str): sender alias for email e.g. edX Support Team
             reply_to (str): Enterprise Customer reply to address for email reply
             attachments (list): list of dicts with filename and url keys
-            campaign_id (str): The id of the campaign this email is associated with
 
         Request message format:
             Content-Type: application/json
@@ -315,7 +313,6 @@ class BrazeClient:
             Body:
                 {
                     "external_user_ids": [ "user1@example.com", "user2@example.org" ],
-                    "campaign_id": "some-campaign-identifier",
                     "messages": {
                         "email": {
                             "app_id": "99999999-9999-9999-9999-999999999999",
@@ -369,7 +366,6 @@ class BrazeClient:
         message = {
             'user_aliases': user_aliases,
             'external_user_ids': external_ids,
-            'campaign_id': campaign_id,
             'recipient_subscription_state': 'all',
             'messages': {
                 'email': email

--- a/ecommerce_worker/email/v1/braze/tasks.py
+++ b/ecommerce_worker/email/v1/braze/tasks.py
@@ -12,7 +12,7 @@ logger = get_task_logger(__name__)
 
 
 def send_offer_assignment_email_via_braze(self, user_email, offer_assignment_id, subject, email_body, sender_alias,
-                                          reply_to, attachments, site_code):
+                                          reply_to, attachments, site_code):  # pylint: disable=invalid-name
     """
     Sends the offer assignment email via Braze.
 
@@ -31,15 +31,13 @@ def send_offer_assignment_email_via_braze(self, user_email, offer_assignment_id,
     try:
         user_emails = [user_email]
         braze_client = get_braze_client(site_code)
-        response = _send_braze_message(
-            braze_client,
+        response = braze_client.send_message(
             email_ids=user_emails,
             subject=subject,
             body=email_body,
             sender_alias=sender_alias,
             reply_to=reply_to,
-            attachments=attachments,
-            campaign_id=config.get('ENTERPRISE_CODE_ASSIGNMENT_CAMPAIGN_ID'),
+            attachments=attachments
         )
         if response and response['success']:
             dispatch_id = response['dispatch_id']
@@ -83,15 +81,13 @@ def send_offer_update_email_via_braze(self, user_email, subject, email_body, sen
     try:
         user_emails = [user_email]
         braze_client = get_braze_client(site_code)
-        _send_braze_message(
-            braze_client,
+        braze_client.send_message(
             email_ids=user_emails,
             subject=subject,
             body=email_body,
             sender_alias=sender_alias,
             reply_to=reply_to,
-            attachments=attachments,
-            campaign_id=config.get('ENTERPRISE_CODE_UPDATE_CAMPAIGN_ID'),
+            attachments=attachments
         )
     except (BrazeRateLimitError, BrazeInternalServerError) as exc:
         raise self.retry(countdown=config.get('BRAZE_RETRY_SECONDS'),
@@ -120,14 +116,12 @@ def send_offer_usage_email_via_braze(self, emails, subject, email_body, reply_to
     try:
         user_emails = list(emails.strip().split(","))
         braze_client = get_braze_client(site_code)
-        _send_braze_message(
-            braze_client,
+        braze_client.send_message(
             email_ids=user_emails,
             subject=subject,
             body=email_body,
             reply_to=reply_to,
-            attachments=attachments,
-            campaign_id=config.get('ENTERPRISE_CODE_USAGE_CAMPAIGN_ID'),
+            attachments=attachments
         )
     except (BrazeRateLimitError, BrazeInternalServerError) as exc:
         raise self.retry(countdown=config.get('BRAZE_RETRY_SECONDS'),
@@ -158,15 +152,13 @@ def send_code_assignment_nudge_email_via_braze(self, email, subject, email_body,
     try:
         user_emails = [email]
         braze_client = get_braze_client(site_code)
-        _send_braze_message(
-            braze_client,
+        braze_client.send_message(
             email_ids=user_emails,
             subject=subject,
             body=email_body,
             sender_alias=sender_alias,
             reply_to=reply_to,
             attachments=attachments,
-            campaign_id=config.get('ENTERPRISE_CODE_NUDGE_CAMPAIGN_ID'),
         )
     except (BrazeRateLimitError, BrazeInternalServerError) as exc:
         raise self.retry(countdown=config.get('BRAZE_RETRY_SECONDS'),
@@ -176,13 +168,3 @@ def send_code_assignment_nudge_email_via_braze(self, email, subject, email_body,
             '[Code Assignment Nudge Email] Error in offer nudge notification with message --- '
             '{message}'.format(message=email_body)
         )
-
-
-def _send_braze_message(braze_client, **kwargs):
-    """
-    Helper to send braze messages.  Pops any falsey `campaign_id`
-    argument before sending.
-    """
-    if 'campaign_id' in kwargs and not kwargs['campaign_id']:
-        kwargs.pop('campaign_id')
-    return braze_client.send_message(**kwargs)

--- a/ecommerce_worker/email/v1/braze/tests/test_tasks.py
+++ b/ecommerce_worker/email/v1/braze/tests/test_tasks.py
@@ -50,10 +50,6 @@ class SendEmailsViaBrazeTests(TestCase):
         'EXPORT_ID_ENDPOINT': '/users/export/ids',
         'CAMPAIGN_SEND_ENDPOINT': '/campaigns/trigger/send',
         'ENTERPRISE_CAMPAIGN_ID': '',
-        'ENTERPRISE_CODE_ASSIGNMENT_CAMPAIGN_ID': 'the-code-assignment-campaign-id',
-        'ENTERPRISE_CODE_UPDATE_CAMPAIGN_ID': 'the-code-update-campaign-id',
-        'ENTERPRISE_CODE_USAGE_CAMPAIGN_ID': 'the-code-usage-campaign-id',
-        'ENTERPRISE_CODE_NUDGE_CAMPAIGN_ID': '',  # cover case where a `campaign_id` kwarg is falsey.
         'FROM_EMAIL': '<edx-for-business-no-reply@info.edx.org>',
         'BRAZE_RETRY_SECONDS': 3600,
         'BRAZE_RETRY_ATTEMPTS': 6,

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def is_requirement(line):
 
 setup(
     name='edx-ecommerce-worker',
-    version='3.1.0',
+    version='3.1.1',
     description='Celery tasks supporting the operations of edX\'s ecommerce service',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
This reverts commit c0eef8edb85fd72f02f919bca5f5d71b4d086162.  Still sorting out the variant ID and campaign id config.
ENT-5285

## Anyone merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production
    - `test.in` for test requirements
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] [Version](https://github.com/edx/ecommerce-worker/blob/master/setup.py) bumped

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/ecommerce-worker/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub CI](https://github.com/edx/ecommerce-worker/actions?query=workflow%3A%22Python+CI%22), verify version has been pushed to [PyPI](https://pypi.org/project/edx-ecommerce-worker/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [ecommerce](https://github.com/edx/ecommerce) to upgrade dependencies (including ecommerce-worker)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in ecommerce will look for the latest version in PyPi.
    - Note: the ecommerce-worker constraint in ecommerce **must** also be bumped to the latest version in PyPi.
- [ ] Deploy `ecommerce`
- [ ] Deploy `ecomworker` on GoCD.
    - While some functions in ecommerce-worker are run via ecommerce, others are handled by a standalone AMI and must be
      released via GoCD.
