### PR TITLE
fix: ignore Braze frequency capping for ent emails

### DIFF
--- a/ecommerce_worker/email/v1/braze/client.py
+++ b/ecommerce_worker/email/v1/braze/client.py
@@ -300,6 +300,11 @@ class BrazeClient:
     ):
         """
         Sends the message via Braze Rest API /messages/send
+        The "override_frequency_capping" key in the request payload is important;
+        it tells Braze to ignore the global campaign message frequency cap
+        for the message we're sending in this method.  Since this is a transactional
+        message, we'd like the recipient to receive it regardless of what/how-many
+        other campaign messages they have received.
 
         Arguments:
             email_ids (list): e.g. ['test1@example.com', 'test2@example.com']
@@ -318,6 +323,7 @@ class BrazeClient:
                 {
                     "external_user_ids": [ "user1@example.com", "user2@example.org" ],
                     "campaign_id": "some-campaign-identifier",
+                    "override_frequency_capping": true,
                     "messages": {
                         "email": {
                             "app_id": "99999999-9999-9999-9999-999999999999",
@@ -374,12 +380,15 @@ class BrazeClient:
         message = {
             'user_aliases': user_aliases,
             'external_user_ids': external_ids,
-            'campaign_id': campaign_id,
             'recipient_subscription_state': 'all',
             'messages': {
                 'email': email
             }
         }
+        if campaign_id:
+            message['campaign_id'] = campaign_id
+            message['override_frequency_capping'] = True
+
         # Scrub the app_id from the log message
         cleaned_message = copy.deepcopy(message)
         cleaned_app_id = '{}...{}'.format(cleaned_message['messages']['email']['app_id'][0:4],

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def is_requirement(line):
 
 setup(
     name='edx-ecommerce-worker',
-    version='3.1.1',
+    version='3.1.2',
     description='Celery tasks supporting the operations of edX\'s ecommerce service',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
## Anyone merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production
    - `test.in` for test requirements
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] [Version](https://github.com/edx/ecommerce-worker/blob/master/setup.py) bumped

**Post merge:**
- [x] Tag pushed and a new [version](https://github.com/edx/ecommerce-worker/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [x] After versioned build finishes in [GitHub CI](https://github.com/edx/ecommerce-worker/actions?query=workflow%3A%22Python+CI%22), verify version has been pushed to [PyPI](https://pypi.org/project/edx-ecommerce-worker/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [x] PR created in [ecommerce](https://github.com/edx/ecommerce) to upgrade dependencies (including ecommerce-worker)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in ecommerce will look for the latest version in PyPi.
    - Note: the ecommerce-worker constraint in ecommerce **must** also be bumped to the latest version in PyPi.
- [ ] Deploy `ecommerce`
- [ ] Deploy `ecomworker` on GoCD.
    - While some functions in ecommerce-worker are run via ecommerce, others are handled by a standalone AMI and must be
      released via GoCD.
