### PR TITLE
docs: Fixed inline link in strongly emphasized warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,7 @@
 ⛔️ DEPRECATION WARNING 
 ======================
-**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see `this announcement <https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839>`__ for more information.**
+This repository is deprecated and in maintainence-only operation while we work on a replacement, please see `this announcement <https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839>`__ for more information.
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to `security@edx.org <mailto:security@edx.org>`__
 


### PR DESCRIPTION
Gross hack, but apparently there's no good workaround for [rst not respecting links in strong emphasis](https://restructuredtext.documatt.com/element/strong-emphasis.html#no-inline-element-nesting)
