### PR TITLE
feat: expose new offer limit email task in api namespace

### DIFF
--- a/ecommerce_worker/email/v1/api.py
+++ b/ecommerce_worker/email/v1/api.py
@@ -5,6 +5,7 @@
 
 # Celery tasks
 from .tasks import (
+    send_api_triggered_offer_usage_email,
     send_code_assignment_nudge_email,
     send_offer_assignment_email,
     send_offer_update_email,

--- a/ecommerce_worker/email/v1/tests/test_api.py
+++ b/ecommerce_worker/email/v1/tests/test_api.py
@@ -15,6 +15,7 @@ class EmailApiTests(TestCase):
         """
         assert [k for k, v in getmembers(api) if not k.startswith('_')] == [
             'did_email_bounce',
+            'send_api_triggered_offer_usage_email',
             'send_code_assignment_nudge_email',
             'send_offer_assignment_email',
             'send_offer_update_email',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def is_requirement(line):
 
 setup(
     name='edx-ecommerce-worker',
-    version='3.3.0',
+    version='3.3.1',
     description='Celery tasks supporting the operations of edX\'s ecommerce service',
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
Quick follow-up to https://github.com/openedx/ecommerce-worker/pull/177

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production
    - `test.in` for test requirements
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] [Version](https://github.com/edx/ecommerce-worker/blob/master/setup.py) bumped

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/ecommerce-worker/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub CI](https://github.com/edx/ecommerce-worker/actions?query=workflow%3A%22Python+CI%22), verify version has been pushed to [PyPI](https://pypi.org/project/edx-ecommerce-worker/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [ecommerce](https://github.com/edx/ecommerce) to upgrade dependencies (including ecommerce-worker)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in ecommerce will look for the latest version in PyPi.
    - Note: the ecommerce-worker constraint in ecommerce **must** also be bumped to the latest version in PyPi.
- [ ] Deploy `ecommerce`
- [ ] Deploy `ecomworker` on GoCD.
    - While some functions in ecommerce-worker are run via ecommerce, others are handled by a standalone AMI and must be
      released via GoCD.
