### PR TITLE
fix: schedule upgrade-python-requirements email monthly

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -2,7 +2,7 @@ name: Upgrade Requirements
 
 on:
   schedule:
-     - cron: "15 1 * * 4"
+     - cron: "15 1 1 * *"
   workflow_dispatch:
      inputs:
        branch:
@@ -15,7 +15,7 @@ jobs:
        branch: ${{ github.event.inputs.branch }}
        team_reviewers: "revenue-squad"
        email_address: revenue-tasks@edx.org  
-       send_success_notification: false
+       send_success_notification: true
     secrets:
        requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
        requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}


### PR DESCRIPTION
## Description

Schedule upgrade-python-requirements GitHub action to email monthly.

## Supporting information

* Jira: [REV-2694](https://2u-internal.atlassian.net/browse/REV-2694)