### PR TITLE
Django 4.2 upgrade

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,9 +6,9 @@
 #
 amqp==2.6.1
     # via kombu
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via redis
 billiard==3.6.4.0
     # via celery
@@ -16,35 +16,36 @@ celery==4.4.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-certifi==2022.12.7
+certifi==2023.7.22
     # via requests
 cffi==1.15.1
     # via pynacl
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
-click==8.1.3
+click==8.1.7
     # via edx-django-utils
-django==3.2.18
+django==3.2.21
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   django-crum
+    #   django-waffle
     #   edx-django-utils
 django-crum==0.7.9
     # via edx-django-utils
-django-waffle==3.0.0
+django-waffle==4.0.0
     # via edx-django-utils
-edx-braze-client==0.1.6
+edx-braze-client==0.1.7
     # via -r requirements/base.in
-edx-django-utils==5.4.0
+edx-django-utils==5.7.0
     # via edx-rest-api-client
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.6.0
     # via -r requirements/base.in
 idna==3.4
     # via requests
 kombu==4.6.11
     # via celery
-newrelic==8.8.0
+newrelic==9.1.0
     # via edx-django-utils
 pbr==5.11.1
     # via stevedore
@@ -52,17 +53,17 @@ psutil==5.9.5
     # via edx-django-utils
 pycparser==2.21
     # via cffi
-pyjwt==2.6.0
+pyjwt==2.8.0
     # via edx-rest-api-client
 pynacl==1.5.0
     # via edx-django-utils
-pytz==2023.3
+pytz==2023.3.post1
     # via
     #   celery
     #   django
-redis==4.5.4
+redis==5.0.1
     # via -r requirements/base.in
-requests==2.28.2
+requests==2.31.0
     # via
     #   edx-rest-api-client
     #   slumber
@@ -72,9 +73,11 @@ slumber==0.7.1
     # via edx-rest-api-client
 sqlparse==0.4.4
     # via django
-stevedore==5.0.0
+stevedore==5.1.0
     # via edx-django-utils
-urllib3==1.26.15
+typing-extensions==4.8.0
+    # via asgiref
+urllib3==2.0.5
     # via requests
 vine==1.3.0
     # via

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -25,8 +25,3 @@ django-simple-history==3.0.0
 # tox>4.0.0 isn't yet compatible with many tox plugins, causing CI failures in almost all repos.
 # Details can be found in this discussion: https://github.com/tox-dev/tox/discussions/1810
 tox<4.0.0
-
-# edx-sphinx-theme is not compatible with latest Sphinx==6.0.0 version 
-# Pinning Sphinx version unless the compatibility issue gets resolved
-# For details, see issue https://github.com/openedx/edx-sphinx-theme/issues/197
-sphinx<6.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,8 +11,7 @@
 # These were previously pinned in ecommerce-worker, and will stay that way
 # until we go through the process of relaxing them gradually.
 
-# some other package are bringing django3.0 so adding constraint.
-Django<3.3
+Django<4.3
 
 # This file contains all common constraints for edx-repos
 -c common_constraints.txt

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -4,5 +4,5 @@
 #
 #    make upgrade
 #
-newrelic==8.8.0
+newrelic==9.1.0
     # via -r requirements/optional.in

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.40.0
+wheel==0.41.2
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.1.2
+pip==23.2.1
     # via -r requirements/pip.in
-setuptools==67.7.2
+setuptools==68.2.2
     # via -r requirements/pip.in

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,20 +4,27 @@
 #
 #    make upgrade
 #
-build==0.10.0
+build==1.0.3
     # via pip-tools
-click==8.1.3
+click==8.1.7
     # via pip-tools
+importlib-metadata==6.8.0
+    # via build
 packaging==23.1
     # via build
-pip-tools==6.13.0
+pip-tools==7.3.0
     # via -r requirements/pip_tools.in
 pyproject-hooks==1.0.0
     # via build
 tomli==2.0.1
-    # via build
-wheel==0.40.0
+    # via
+    #   build
+    #   pip-tools
+    #   pyproject-hooks
+wheel==0.41.2
     # via pip-tools
+zipp==3.17.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,11 +8,11 @@ amqp==2.6.1
     # via
     #   -r requirements/base.txt
     #   kombu
-asgiref==3.6.0
+asgiref==3.7.2
     # via
     #   -r requirements/base.txt
     #   django
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via
     #   -r requirements/base.txt
     #   redis
@@ -24,7 +24,7 @@ celery==4.4.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-certifi==2022.12.7
+certifi==2023.7.22
     # via
     #   -r requirements/base.txt
     #   requests
@@ -32,36 +32,37 @@ cffi==1.15.1
     # via
     #   -r requirements/base.txt
     #   pynacl
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.1.3
+click==8.1.7
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-django==3.2.18
+django==3.2.21
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-crum
+    #   django-waffle
     #   edx-django-utils
 django-crum==0.7.9
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-django-waffle==3.0.0
+django-waffle==4.0.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-edx-braze-client==0.1.6
+edx-braze-client==0.1.7
     # via -r requirements/base.txt
-edx-django-utils==5.4.0
+edx-django-utils==5.7.0
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.6.0
     # via -r requirements/base.txt
 idna==3.4
     # via
@@ -71,7 +72,7 @@ kombu==4.6.11
     # via
     #   -r requirements/base.txt
     #   celery
-newrelic==8.8.0
+newrelic==9.1.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -87,7 +88,7 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pyjwt==2.6.0
+pyjwt==2.8.0
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
@@ -95,16 +96,16 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pytz==2023.3
+pytz==2023.3.post1
     # via
     #   -r requirements/base.txt
     #   celery
     #   django
-pyyaml==6.0
+pyyaml==6.0.1
     # via -r requirements/production.in
-redis==4.5.4
+redis==5.0.1
     # via -r requirements/base.txt
-requests==2.28.2
+requests==2.31.0
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
@@ -119,11 +120,15 @@ sqlparse==0.4.4
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-urllib3==1.26.15
+typing-extensions==4.8.0
+    # via
+    #   -r requirements/base.txt
+    #   asgiref
+urllib3==2.0.5
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,16 +8,16 @@ amqp==2.6.1
     # via
     #   -r requirements/base.txt
     #   kombu
-asgiref==3.6.0
+asgiref==3.7.2
     # via
     #   -r requirements/base.txt
     #   django
-astroid==2.15.4
+astroid==2.15.8
     # via
     #   -r requirements/test.in
     #   pylint
     #   pylint-celery
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via
     #   -r requirements/base.txt
     #   redis
@@ -29,7 +29,7 @@ celery==4.4.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-certifi==2022.12.7
+certifi==2023.7.22
     # via
     #   -r requirements/base.txt
     #   requests
@@ -37,11 +37,11 @@ cffi==1.15.1
     # via
     #   -r requirements/base.txt
     #   pynacl
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.1.3
+click==8.1.7
     # via
     #   -r requirements/base.txt
     #   click-log
@@ -50,41 +50,42 @@ click==8.1.3
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==1.3.0
+code-annotations==1.5.0
     # via edx-lint
-coverage[toml]==7.2.3
+coverage[toml]==7.3.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
 ddt==1.6.0
     # via -r requirements/test.in
-dill==0.3.6
+dill==0.3.7
     # via pylint
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-crum
+    #   django-waffle
     #   edx-django-utils
 django-crum==0.7.9
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-django-waffle==3.0.0
+django-waffle==4.0.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-edx-braze-client==0.1.6
+edx-braze-client==0.1.7
     # via -r requirements/base.txt
-edx-django-utils==5.4.0
+edx-django-utils==5.7.0
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
 edx-lint==5.3.4
     # via -r requirements/test.in
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.6.0
     # via -r requirements/base.txt
-exceptiongroup==1.1.1
+exceptiongroup==1.1.3
     # via pytest
 idna==3.4
     # via
@@ -102,13 +103,13 @@ kombu==4.6.11
     #   celery
 lazy-object-proxy==1.9.0
     # via astroid
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 mccabe==0.7.0
     # via pylint
-mock==5.0.2
+mock==5.1.0
     # via -r requirements/test.in
-newrelic==8.8.0
+newrelic==9.1.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -118,25 +119,25 @@ pbr==5.11.1
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==3.3.0
+platformdirs==3.10.0
     # via pylint
-pluggy==1.0.0
+pluggy==1.3.0
     # via pytest
 psutil==5.9.5
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pycodestyle==2.10.0
+pycodestyle==2.11.0
     # via -r requirements/test.in
 pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pyjwt==2.6.0
+pyjwt==2.8.0
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-pylint==2.17.3
+pylint==2.17.6
     # via
     #   -r requirements/test.in
     #   edx-lint
@@ -149,7 +150,7 @@ pylint-django==2.5.3
     # via
     #   -r requirements/test.in
     #   edx-lint
-pylint-plugin-utils==0.7
+pylint-plugin-utils==0.8.2
     # via
     #   -r requirements/test.in
     #   pylint-celery
@@ -158,32 +159,32 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pytest==7.3.1
+pytest==7.4.2
     # via
     #   -r requirements/test.in
     #   pytest-cov
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.in
 python-slugify==8.0.1
     # via code-annotations
-pytz==2023.3
+pytz==2023.3.post1
     # via
     #   -r requirements/base.txt
     #   celery
     #   django
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   code-annotations
     #   responses
-redis==4.5.4
+redis==5.0.1
     # via -r requirements/base.txt
-requests==2.28.2
+requests==2.31.0
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
     #   responses
     #   slumber
-responses==0.23.1
+responses==0.23.3
     # via -r requirements/test.in
 six==1.16.0
     # via
@@ -197,12 +198,12 @@ sqlparse==0.4.4
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-utils
-testfixtures==7.1.0
+testfixtures==7.2.0
     # via -r requirements/test.in
 text-unidecode==1.3
     # via python-slugify
@@ -211,15 +212,17 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.7
+tomlkit==0.12.1
     # via pylint
-types-pyyaml==6.0.12.9
+types-pyyaml==6.0.12.12
     # via responses
-typing-extensions==4.5.0
+typing-extensions==4.8.0
     # via
+    #   -r requirements/base.txt
+    #   asgiref
     #   astroid
     #   pylint
-urllib3==1.26.15
+urllib3==2.0.5
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-distlib==0.3.6
+distlib==0.3.7
     # via virtualenv
-filelock==3.12.0
+filelock==3.12.4
     # via
     #   tox
     #   virtualenv
 packaging==23.1
     # via tox
-platformdirs==3.3.0
+platformdirs==3.10.0
     # via virtualenv
-pluggy==1.0.0
+pluggy==1.3.0
     # via tox
 py==1.11.0
     # via tox
@@ -27,7 +27,7 @@ tox==3.28.0
     #   -c requirements/common_constraints.txt
     #   -r requirements/tox.in
     #   tox-battery
-tox-battery==0.6.1
+tox-battery==0.6.2
     # via -r requirements/tox.in
-virtualenv==20.22.0
+virtualenv==20.24.5
     # via tox


### PR DESCRIPTION
# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

Issue: [edx/#206](https://github.com/openedx/public-engineering/issues/206)

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

**Merge checklist:**
- [X] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production
    - `test.in` for test requirements
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] [Version](https://github.com/openedx/ecommerce-worker/blob/master/setup.py) bumped

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/ecommerce-worker/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub CI](https://github.com/openedx/ecommerce-worker/actions?query=workflow%3A%22Python+CI%22), verify version has been pushed to [PyPI](https://pypi.org/project/edx-ecommerce-worker/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [ecommerce](https://github.com/openedx/ecommerce) to upgrade dependencies (including ecommerce-worker)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in ecommerce will look for the latest version in PyPi.
    - Note: the ecommerce-worker constraint in ecommerce **must** also be bumped to the latest version in PyPi.
- [ ] Deploy `ecommerce`
- [ ] Deploy `ecomworker` on GoCD.
    - While some functions in ecommerce-worker are run via ecommerce, others are handled by a standalone AMI and must be
      released via GoCD.
