### PR TITLE
upgrade pyyaml version to make it compatible with python 3.12.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,10 +16,8 @@ backports-zoneinfo[tzdata]==0.2.1
     #   kombu
 billiard==4.2.0
     # via celery
-celery==5.3.6
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+celery==5.4.0
+    # via -r requirements/base.in
 certifi==2024.2.2
     # via requests
 cffi==1.16.0
@@ -60,7 +58,7 @@ idna==3.7
     # via requests
 kombu==5.3.7
     # via celery
-newrelic==9.8.0
+newrelic==9.9.0
     # via edx-django-utils
 pbr==6.0.0
     # via stevedore

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,79 +4,110 @@
 #
 #    make upgrade
 #
-amqp==2.6.1
+amqp==5.2.0
     # via kombu
-asgiref==3.6.0
+asgiref==3.8.1
     # via django
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via redis
-billiard==3.6.4.0
+backports-zoneinfo[tzdata]==0.2.1
+    # via
+    #   celery
+    #   kombu
+billiard==4.2.0
     # via celery
-celery==4.4.7
+celery==5.3.6
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-certifi==2022.12.7
+certifi==2024.2.2
     # via requests
-cffi==1.15.1
+cffi==1.16.0
     # via pynacl
-charset-normalizer==3.1.0
+charset-normalizer==3.3.2
     # via requests
-click==8.1.3
-    # via edx-django-utils
-django==3.2.18
+click==8.1.7
+    # via
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
+    #   edx-django-utils
+click-didyoumean==0.3.1
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.3.0
+    # via celery
+django==3.2.25
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   django-crum
+    #   django-waffle
     #   edx-django-utils
 django-crum==0.7.9
     # via edx-django-utils
-django-waffle==3.0.0
+django-waffle==4.1.0
     # via edx-django-utils
-edx-braze-client==0.1.6
+edx-braze-client==0.2.3
     # via -r requirements/base.in
-edx-django-utils==5.4.0
+edx-django-utils==5.12.0
     # via edx-rest-api-client
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.7.0
     # via -r requirements/base.in
-idna==3.4
+idna==3.7
     # via requests
-kombu==4.6.11
+kombu==5.3.7
     # via celery
-newrelic==8.8.0
+newrelic==9.8.0
     # via edx-django-utils
-pbr==5.11.1
+pbr==6.0.0
     # via stevedore
-psutil==5.9.5
+prompt-toolkit==3.0.43
+    # via click-repl
+psutil==5.9.8
     # via edx-django-utils
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pyjwt==2.6.0
+pyjwt==2.8.0
     # via edx-rest-api-client
 pynacl==1.5.0
     # via edx-django-utils
-pytz==2023.3
-    # via
-    #   celery
-    #   django
-redis==4.5.4
+python-dateutil==2.9.0.post0
+    # via celery
+pytz==2024.1
+    # via django
+redis==5.0.3
     # via -r requirements/base.in
-requests==2.28.2
+requests==2.31.0
     # via
     #   edx-rest-api-client
     #   slumber
 six==1.16.0
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   python-dateutil
 slumber==0.7.1
     # via edx-rest-api-client
-sqlparse==0.4.4
+sqlparse==0.5.0
     # via django
-stevedore==5.0.0
+stevedore==5.2.0
     # via edx-django-utils
-urllib3==1.26.15
+typing-extensions==4.11.0
+    # via
+    #   asgiref
+    #   kombu
+tzdata==2024.1
+    # via
+    #   backports-zoneinfo
+    #   celery
+urllib3==2.2.1
     # via requests
-vine==1.3.0
+vine==5.1.0
     # via
     #   amqp
     #   celery
+    #   kombu
+wcwidth==0.2.13
+    # via prompt-toolkit

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,8 +10,9 @@ asgiref==3.8.1
     # via django
 async-timeout==4.0.3
     # via redis
-backports-zoneinfo[tzdata]==0.2.1
+backports-zoneinfo[tzdata]==0.2.1 ; python_version < "3.9"
     # via
+    #   -c requirements/constraints.txt
     #   celery
     #   kombu
 billiard==4.2.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -17,5 +17,5 @@ Django<3.3
 # This file contains all common constraints for edx-repos
 -c common_constraints.txt
 
-# breaking changes in CLI and dropped support for python3.5 in celery 5.0
-celery<6.0.0
+# # breaking changes in CLI and dropped support for python3.5 in celery 5.0
+# celery<6.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -17,5 +17,6 @@ Django<3.3
 # This file contains all common constraints for edx-repos
 -c common_constraints.txt
 
-# # breaking changes in CLI and dropped support for python3.5 in celery 5.0
-# celery<6.0.0
+# backports-zoneinfo comes by-default in newer versions of python
+# it gives error while building wheel with python>=3.9
+backports.zoneinfo ; python_version < "3.9"

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -18,4 +18,4 @@ Django<3.3
 -c common_constraints.txt
 
 # breaking changes in CLI and dropped support for python3.5 in celery 5.0
-celery<5.0
+celery<6.0.0

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -4,5 +4,5 @@
 #
 #    make upgrade
 #
-newrelic==9.8.0
+newrelic==9.9.0
     # via -r requirements/optional.in

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -4,5 +4,5 @@
 #
 #    make upgrade
 #
-newrelic==8.8.0
+newrelic==9.8.0
     # via -r requirements/optional.in

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.40.0
+wheel==0.43.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.1.2
+pip==24.0
     # via -r requirements/pip.in
-setuptools==67.7.2
+setuptools==69.5.1
     # via -r requirements/pip.in

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,20 +4,29 @@
 #
 #    make upgrade
 #
-build==0.10.0
+build==1.2.1
     # via pip-tools
-click==8.1.3
+click==8.1.7
     # via pip-tools
-packaging==23.1
+importlib-metadata==7.1.0
     # via build
-pip-tools==6.13.0
+packaging==24.0
+    # via build
+pip-tools==7.4.1
     # via -r requirements/pip_tools.in
 pyproject-hooks==1.0.0
-    # via build
+    # via
+    #   build
+    #   pip-tools
 tomli==2.0.1
-    # via build
-wheel==0.40.0
+    # via
+    #   build
+    #   pip-tools
+    #   pyproject-hooks
+wheel==0.43.0
     # via pip-tools
+zipp==3.18.1
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -25,10 +25,8 @@ billiard==4.2.0
     # via
     #   -r requirements/base.txt
     #   celery
-celery==5.3.6
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+celery==5.4.0
+    # via -r requirements/base.txt
 certifi==2024.2.2
     # via
     #   -r requirements/base.txt
@@ -93,7 +91,7 @@ kombu==5.3.7
     # via
     #   -r requirements/base.txt
     #   celery
-newrelic==9.8.0
+newrelic==9.9.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -16,8 +16,9 @@ async-timeout==4.0.3
     # via
     #   -r requirements/base.txt
     #   redis
-backports-zoneinfo[tzdata]==0.2.1
+backports-zoneinfo[tzdata]==0.2.1 ; python_version < "3.9"
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   celery
     #   kombu

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,90 +4,116 @@
 #
 #    make upgrade
 #
-amqp==2.6.1
+amqp==5.2.0
     # via
     #   -r requirements/base.txt
     #   kombu
-asgiref==3.6.0
+asgiref==3.8.1
     # via
     #   -r requirements/base.txt
     #   django
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via
     #   -r requirements/base.txt
     #   redis
-billiard==3.6.4.0
+backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/base.txt
     #   celery
-celery==4.4.7
+    #   kombu
+billiard==4.2.0
+    # via
+    #   -r requirements/base.txt
+    #   celery
+celery==5.3.6
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-certifi==2022.12.7
+certifi==2024.2.2
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==1.15.1
+cffi==1.16.0
     # via
     #   -r requirements/base.txt
     #   pynacl
-charset-normalizer==3.1.0
+charset-normalizer==3.3.2
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.1.3
+click==8.1.7
     # via
     #   -r requirements/base.txt
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
     #   edx-django-utils
-django==3.2.18
+click-didyoumean==0.3.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
+click-plugins==1.1.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
+click-repl==0.3.0
+    # via
+    #   -r requirements/base.txt
+    #   celery
+django==3.2.25
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-crum
+    #   django-waffle
     #   edx-django-utils
 django-crum==0.7.9
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-django-waffle==3.0.0
+django-waffle==4.1.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-edx-braze-client==0.1.6
+edx-braze-client==0.2.3
     # via -r requirements/base.txt
-edx-django-utils==5.4.0
+edx-django-utils==5.12.0
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.7.0
     # via -r requirements/base.txt
-idna==3.4
+idna==3.7
     # via
     #   -r requirements/base.txt
     #   requests
-kombu==4.6.11
+kombu==5.3.7
     # via
     #   -r requirements/base.txt
     #   celery
-newrelic==8.8.0
+newrelic==9.8.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/base.txt
     #   stevedore
-psutil==5.9.5
+prompt-toolkit==3.0.43
+    # via
+    #   -r requirements/base.txt
+    #   click-repl
+psutil==5.9.8
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pycparser==2.21
+pycparser==2.22
     # via
     #   -r requirements/base.txt
     #   cffi
-pyjwt==2.6.0
+pyjwt==2.8.0
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
@@ -95,40 +121,60 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pytz==2023.3
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
     #   celery
+pytz==2024.1
+    # via
+    #   -r requirements/base.txt
     #   django
-pyyaml==6.0
+pyyaml==6.0.1
     # via -r requirements/production.in
-redis==4.5.4
+redis==5.0.3
     # via -r requirements/base.txt
-requests==2.28.2
+requests==2.31.0
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
     #   slumber
 six==1.16.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   python-dateutil
 slumber==0.7.1
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-sqlparse==0.4.4
+sqlparse==0.5.0
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.0.0
+stevedore==5.2.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-urllib3==1.26.15
+typing-extensions==4.11.0
+    # via
+    #   -r requirements/base.txt
+    #   asgiref
+    #   kombu
+tzdata==2024.1
+    # via
+    #   -r requirements/base.txt
+    #   backports-zoneinfo
+    #   celery
+urllib3==2.2.1
     # via
     #   -r requirements/base.txt
     #   requests
-vine==1.3.0
+vine==5.1.0
     # via
     #   -r requirements/base.txt
     #   amqp
     #   celery
+    #   kombu
+wcwidth==0.2.13
+    # via
+    #   -r requirements/base.txt
+    #   prompt-toolkit

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,139 +4,163 @@
 #
 #    make upgrade
 #
-amqp==2.6.1
+amqp==5.2.0
     # via
     #   -r requirements/base.txt
     #   kombu
-asgiref==3.6.0
+asgiref==3.8.1
     # via
     #   -r requirements/base.txt
     #   django
-astroid==2.15.4
+astroid==3.1.0
     # via
     #   -r requirements/test.in
     #   pylint
     #   pylint-celery
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via
     #   -r requirements/base.txt
     #   redis
-billiard==3.6.4.0
+backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/base.txt
     #   celery
-celery==4.4.7
+    #   kombu
+billiard==4.2.0
+    # via
+    #   -r requirements/base.txt
+    #   celery
+celery==5.3.6
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-certifi==2022.12.7
+certifi==2024.2.2
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==1.15.1
+cffi==1.16.0
     # via
     #   -r requirements/base.txt
     #   pynacl
-charset-normalizer==3.1.0
+charset-normalizer==3.3.2
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.1.3
+click==8.1.7
     # via
     #   -r requirements/base.txt
+    #   celery
+    #   click-didyoumean
     #   click-log
+    #   click-plugins
+    #   click-repl
     #   code-annotations
     #   edx-django-utils
     #   edx-lint
+click-didyoumean==0.3.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
 click-log==0.4.0
     # via edx-lint
-code-annotations==1.3.0
+click-plugins==1.1.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
+click-repl==0.3.0
+    # via
+    #   -r requirements/base.txt
+    #   celery
+code-annotations==1.8.0
     # via edx-lint
-coverage[toml]==7.2.3
+coverage[toml]==7.4.4
     # via
     #   -r requirements/test.in
     #   pytest-cov
-ddt==1.6.0
+ddt==1.7.2
     # via -r requirements/test.in
-dill==0.3.6
+dill==0.3.8
     # via pylint
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-crum
+    #   django-waffle
     #   edx-django-utils
 django-crum==0.7.9
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-django-waffle==3.0.0
+django-waffle==4.1.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-edx-braze-client==0.1.6
+edx-braze-client==0.2.3
     # via -r requirements/base.txt
-edx-django-utils==5.4.0
+edx-django-utils==5.12.0
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-edx-lint==5.3.4
+edx-lint==5.3.6
     # via -r requirements/test.in
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.7.0
     # via -r requirements/base.txt
-exceptiongroup==1.1.1
+exceptiongroup==1.2.0
     # via pytest
-idna==3.4
+idna==3.7
     # via
     #   -r requirements/base.txt
     #   requests
 iniconfig==2.0.0
     # via pytest
-isort==5.12.0
+isort==5.13.2
     # via pylint
-jinja2==3.1.2
+jinja2==3.1.3
     # via code-annotations
-kombu==4.6.11
+kombu==5.3.7
     # via
     #   -r requirements/base.txt
     #   celery
-lazy-object-proxy==1.9.0
-    # via astroid
-markupsafe==2.1.2
+markupsafe==2.1.5
     # via jinja2
 mccabe==0.7.0
     # via pylint
-mock==5.0.2
+mock==5.1.0
     # via -r requirements/test.in
-newrelic==8.8.0
+newrelic==9.8.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-packaging==23.1
+packaging==24.0
     # via pytest
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==3.3.0
+platformdirs==4.2.0
     # via pylint
-pluggy==1.0.0
+pluggy==1.4.0
     # via pytest
-psutil==5.9.5
+prompt-toolkit==3.0.43
+    # via
+    #   -r requirements/base.txt
+    #   click-repl
+psutil==5.9.8
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pycodestyle==2.10.0
+pycodestyle==2.11.1
     # via -r requirements/test.in
-pycparser==2.21
+pycparser==2.22
     # via
     #   -r requirements/base.txt
     #   cffi
-pyjwt==2.6.0
+pyjwt==2.8.0
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-pylint==2.17.3
+pylint==3.1.0
     # via
     #   -r requirements/test.in
     #   edx-lint
@@ -145,11 +169,11 @@ pylint==2.17.3
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.5.3
+pylint-django==2.5.5
     # via
     #   -r requirements/test.in
     #   edx-lint
-pylint-plugin-utils==0.7
+pylint-plugin-utils==0.8.2
     # via
     #   -r requirements/test.in
     #   pylint-celery
@@ -158,51 +182,55 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pytest==7.3.1
+pytest==8.1.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
-pytest-cov==4.0.0
+pytest-cov==5.0.0
     # via -r requirements/test.in
-python-slugify==8.0.1
-    # via code-annotations
-pytz==2023.3
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
     #   celery
+python-slugify==8.0.4
+    # via code-annotations
+pytz==2024.1
+    # via
+    #   -r requirements/base.txt
     #   django
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   code-annotations
     #   responses
-redis==4.5.4
+redis==5.0.3
     # via -r requirements/base.txt
-requests==2.28.2
+requests==2.31.0
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
     #   responses
     #   slumber
-responses==0.23.1
+responses==0.25.0
     # via -r requirements/test.in
 six==1.16.0
     # via
     #   -r requirements/base.txt
     #   edx-lint
+    #   python-dateutil
 slumber==0.7.1
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-sqlparse==0.4.4
+sqlparse==0.5.0
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.0.0
+stevedore==5.2.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-utils
-testfixtures==7.1.0
+testfixtures==8.1.0
     # via -r requirements/test.in
 text-unidecode==1.3
     # via python-slugify
@@ -211,23 +239,32 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.7
+tomlkit==0.12.4
     # via pylint
-types-pyyaml==6.0.12.9
-    # via responses
-typing-extensions==4.5.0
+typing-extensions==4.11.0
     # via
+    #   -r requirements/base.txt
+    #   asgiref
     #   astroid
+    #   kombu
     #   pylint
-urllib3==1.26.15
+tzdata==2024.1
+    # via
+    #   -r requirements/base.txt
+    #   backports-zoneinfo
+    #   celery
+urllib3==2.2.1
     # via
     #   -r requirements/base.txt
     #   requests
     #   responses
-vine==1.3.0
+vine==5.1.0
     # via
     #   -r requirements/base.txt
     #   amqp
     #   celery
-wrapt==1.15.0
-    # via astroid
+    #   kombu
+wcwidth==0.2.13
+    # via
+    #   -r requirements/base.txt
+    #   prompt-toolkit

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -21,8 +21,9 @@ async-timeout==4.0.3
     # via
     #   -r requirements/base.txt
     #   redis
-backports-zoneinfo[tzdata]==0.2.1
+backports-zoneinfo[tzdata]==0.2.1 ; python_version < "3.9"
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   celery
     #   kombu

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -30,10 +30,8 @@ billiard==4.2.0
     # via
     #   -r requirements/base.txt
     #   celery
-celery==5.3.6
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+celery==5.4.0
+    # via -r requirements/base.txt
 certifi==2024.2.2
     # via
     #   -r requirements/base.txt
@@ -106,7 +104,7 @@ edx-lint==5.3.6
     # via -r requirements/test.in
 edx-rest-api-client==5.7.0
     # via -r requirements/base.txt
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via pytest
 idna==3.7
     # via
@@ -128,7 +126,7 @@ mccabe==0.7.0
     # via pylint
 mock==5.1.0
     # via -r requirements/test.in
-newrelic==9.8.0
+newrelic==9.9.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-distlib==0.3.6
+distlib==0.3.8
     # via virtualenv
-filelock==3.12.0
+filelock==3.13.4
     # via
     #   tox
     #   virtualenv
-packaging==23.1
+packaging==24.0
     # via tox
-platformdirs==3.3.0
+platformdirs==4.2.0
     # via virtualenv
-pluggy==1.0.0
+pluggy==1.4.0
     # via tox
 py==1.11.0
     # via tox
@@ -27,7 +27,7 @@ tox==3.28.0
     #   -c requirements/common_constraints.txt
     #   -r requirements/tox.in
     #   tox-battery
-tox-battery==0.6.1
+tox-battery==0.6.2
     # via -r requirements/tox.in
-virtualenv==20.22.0
+virtualenv==20.25.1
     # via tox

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -29,5 +29,5 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.2
     # via -r requirements/tox.in
-virtualenv==20.25.1
+virtualenv==20.25.3
     # via tox


### PR DESCRIPTION
pyyaml==6.0 is not compatible with python 3.12.
pyyaml==6.0.1 is compatible with python 3.8.0 to 3.12.2.
celery=4.x is also not compatible with 3.12.2. It throws below error
```
2024-04-15 12:36:32 Traceback (most recent call last):
2024-04-15 12:36:32   File "/openedx/venv/bin/celery", line 5, in <module>
2024-04-15 12:36:32     from celery.__main__ import main
2024-04-15 12:36:32   File "/openedx/venv/lib/python3.12/site-packages/celery/__init__.py", line 19, in <module>
2024-04-15 12:36:32     from . import local  # noqa
2024-04-15 12:36:32     ^^^^^^^^^^^^^^^^^^^
2024-04-15 12:36:32   File "/openedx/venv/lib/python3.12/site-packages/celery/local.py", line 17, in <module>
2024-04-15 12:36:32     from .five import PY3, bytes_if_py2, items, string, string_t
2024-04-15 12:36:32   File "/openedx/venv/lib/python3.12/site-packages/celery/five.py", line 7, in <module>
2024-04-15 12:36:32     import vine.five
2024-04-15 12:36:32   File "/openedx/venv/lib/python3.12/site-packages/vine/__init__.py", line 8, in <module>
2024-04-15 12:36:32     from .abstract import Thenable
2024-04-15 12:36:32   File "/openedx/venv/lib/python3.12/site-packages/vine/abstract.py", line 6, in <module>
2024-04-15 12:36:32     from .five import with_metaclass, Callable
2024-04-15 12:36:32   File "/openedx/venv/lib/python3.12/site-packages/vine/five.py", line 364, in <module>
2024-04-15 12:36:32     from inspect import formatargspec, getargspec as _getargspec  # noqa
2024-04-15 12:36:32     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-15 12:36:32 ImportError: cannot import name 'formatargspec' from 'inspect' (/opt/pyenv/versions/3.12.2/lib/python3.12/inspect.py). Did you mean: 'formatargvalues'?
```

backports-zoneinfo comes by-default in newer versions of python
it gives error while building wheel with python>=3.9
```
100.5 Downloading zope.interface-6.3-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (255 kB)
101.6    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 255.4/255.4 kB 223.8 kB/s eta 0:00:00
102.2 Building wheels for collected packages: backports-zoneinfo
102.2   Building wheel for backports-zoneinfo (pyproject.toml): started
102.8   Building wheel for backports-zoneinfo (pyproject.toml): finished with status 'error'
102.8   error: subprocess-exited-with-error
102.8
102.8   × Building wheel for backports-zoneinfo (pyproject.toml) did not run successfully.
102.8   │ exit code: 1
102.8   ╰─> [41 lines of output]
102.8       running bdist_wheel
102.8       running build
102.8       running build_py
102.8       creating build
102.8       creating build/lib.linux-x86_64-cpython-312
102.8       creating build/lib.linux-x86_64-cpython-312/backports
102.8       copying src/backports/__init__.py -> build/lib.linux-x86_64-cpython-312/backports
102.8       creating build/lib.linux-x86_64-cpython-312/backports/zoneinfo
102.8       copying src/backports/zoneinfo/_common.py -> build/lib.linux-x86_64-cpython-312/backports/zoneinfo
102.8       copying src/backports/zoneinfo/_version.py -> build/lib.linux-x86_64-cpython-312/backports/zoneinfo
102.8       copying src/backports/zoneinfo/_zoneinfo.py -> build/lib.linux-x86_64-cpython-312/backports/zoneinfo
102.8       copying src/backports/zoneinfo/__init__.py -> build/lib.linux-x86_64-cpython-312/backports/zoneinfo
102.8       copying src/backports/zoneinfo/_tzpath.py -> build/lib.linux-x86_64-cpython-312/backports/zoneinfo
102.8       running egg_info
102.8       writing src/backports.zoneinfo.egg-info/PKG-INFO
102.8       writing dependency_links to src/backports.zoneinfo.egg-info/dependency_links.txt
102.8       writing requirements to src/backports.zoneinfo.egg-info/requires.txt
102.8       writing top-level names to src/backports.zoneinfo.egg-info/top_level.txt
102.8       reading manifest file 'src/backports.zoneinfo.egg-info/SOURCES.txt'
102.8       reading manifest template 'MANIFEST.in'
102.8       warning: no files found matching '*.png' under directory 'docs'
102.8       warning: no files found matching '*.svg' under directory 'docs'
102.8       no previously-included directories found matching 'docs/_build'
102.8       no previously-included directories found matching 'docs/_output'
102.8       adding license file 'LICENSE'
102.8       adding license file 'licenses/LICENSE_APACHE'
102.8       writing manifest file 'src/backports.zoneinfo.egg-info/SOURCES.txt'
102.8       copying src/backports/zoneinfo/__init__.pyi -> build/lib.linux-x86_64-cpython-312/backports/zoneinfo
102.8       copying src/backports/zoneinfo/py.typed -> build/lib.linux-x86_64-cpython-312/backports/zoneinfo
102.8       running build_ext
102.8       building 'backports.zoneinfo._czoneinfo' extension
102.8       creating build/temp.linux-x86_64-cpython-312
102.8       creating build/temp.linux-x86_64-cpython-312/lib
102.8       gcc -pthread -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -I/openedx/venv/include -I/opt/pyenv/versions/3.12.2/include/python3.12 -c lib/zoneinfo_module.c -o build/temp.linux-x86_64-cpython-312/lib/zoneinfo_module.o -std=c99
102.8       lib/zoneinfo_module.c: In function ‘zoneinfo_fromutc’:
102.8       lib/zoneinfo_module.c:600:19: error: ‘_PyLong_One’ undeclared (first use in this function); did you mean ‘_PyLong_New’?
102.8         600 |             one = _PyLong_One;
102.8             |                   ^~~~~~~~~~~
102.8             |                   _PyLong_New
102.8       lib/zoneinfo_module.c:600:19: note: each undeclared identifier is reported only once for each function it appears in
102.8       error: command '/usr/bin/gcc' failed with exit code 1
102.8       [end of output]
102.8
102.8   note: This error originates from a subprocess, and is likely not a problem with pip.
102.8   ERROR: Failed building wheel for backports-zoneinfo
102.8 Failed to build backports-zoneinfo
102.8 ERROR: Could not build wheels for backports-zoneinfo, which is required to install pyproject.toml-based projects
------
Dockerfile:83
--------------------
  81 |
  82 |     # python requirements
  83 | >>> RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared,uid=${APP_USER_ID} pip install -r requirements.txt
  84 |     # https://pypi.org/project/uWSGI/
  85 |     RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared,uid=${APP_USER_ID} pip install uwsgi==2.0.24
--------------------
ERROR: failed to solve: process "/bin/sh -c pip install -r requirements.txt" did not complete successfully: exit code: 1
```

Upgraded Celery in this PR through constraints.txt which also resolves other dependencies conflicts with python 3.12.2.
This change is necessary to be merged to close this [issue](https://github.com/overhangio/tutor-ecommerce/issues/68) in tutor-ecommerce.