### PR TITLE
chore: update Django to 3.2.25 for Quince - Security Patch

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,7 +24,7 @@ charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via edx-django-utils
-django==3.2.24
+django==3.2.25
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -40,7 +40,7 @@ click==8.1.3
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-django==3.2.24
+django==3.2.25
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt


### PR DESCRIPTION
See: https://github.com/openedx/wg-build-test-release/issues/341