### PR TITLE
build: add python 3.11 and 3.12 ci checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,18 +30,31 @@ jobs:
     - name: Build Docker
       run: |
         docker compose -f .github/docker-compose-ci.yml up -d
-        docker exec ecomworker bash -c "sudo apt-get update -y; sudo apt-get install python${{ matrix.python-version }} python${{ matrix.python-version }}-dev -y;"
-
+        docker exec ecomworker bash -c "
+        sudo apt-get update -y &&
+        sudo apt-get install python${{ matrix.python-version }} \
+        python${{ matrix.python-version }}-dev \
+        python${{ matrix.python-version }}-distutils -y &&
+        curl -sS https://bootstrap.pypa.io/get-pip.py | python${{ matrix.python-version }};"
+        # Need to install pip from source here^ otherwise some packages don't get installed
     - name: Format Python Version
       run: |
         PYTHON_VERSION=${{ matrix.python-version }}
         FORMATTED_VERSION=${PYTHON_VERSION/3./py3} 
         echo "PYTHON_VERSION=$FORMATTED_VERSION" >> $GITHUB_ENV
+    - name: Install dependencies
+      run: |
+          docker exec -t ecomworker bash -c "
+            cd /edx/app/ecomworker/ecomworker &&
+            python${{ matrix.python-version }} -m pip install tox
+          "
     - name: Run Tests
       env:
         TARGETS: ${{ matrix.test-target }}
       run: |
-        docker exec ecomworker bash -c "cd /edx/app/ecomworker/ecomworker && PYTHON_VERSION=$PYTHON_VERSION make $TARGETS"
+        docker exec ecomworker bash -c "
+        cd /edx/app/ecomworker/ecomworker &&
+        PYTHON_VERSION=${{ matrix.python-version }} PYTHON_ENV=$PYTHON_VERSION make $TARGETS"
 
     - name: Run Coverage
       if: matrix.test-target == 'test' && matrix.python-version == '3.8'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        python-version: [3.8]
+        python-version: [3.8, 3.11, 3.12]
         test-target: [test, quality]
 
     steps:
@@ -29,17 +29,22 @@ jobs:
 
     - name: Build Docker
       run: |
-        docker-compose -f .github/docker-compose-ci.yml up -d
-        docker exec ecomworker bash -c "sudo apt update -y; sudo apt install python3-dev -y;"
+        docker compose -f .github/docker-compose-ci.yml up -d
+        docker exec ecomworker bash -c "sudo apt-get update -y; sudo apt-get install python${{ matrix.python-version }} python${{ matrix.python-version }}-dev -y;"
 
+    - name: Format Python Version
+      run: |
+        PYTHON_VERSION=${{ matrix.python-version }}
+        FORMATTED_VERSION=${PYTHON_VERSION/3./py3} 
+        echo "PYTHON_VERSION=$FORMATTED_VERSION" >> $GITHUB_ENV
     - name: Run Tests
       env:
         TARGETS: ${{ matrix.test-target }}
       run: |
-        docker exec ecomworker bash -c "cd /edx/app/ecomworker/ecomworker && make $TARGETS"
+        docker exec ecomworker bash -c "cd /edx/app/ecomworker/ecomworker && PYTHON_VERSION=$PYTHON_VERSION make $TARGETS"
 
     - name: Run Coverage
-      if: matrix.test-target == 'test'
+      if: matrix.test-target == 'test' && matrix.python-version == '3.8'
       run: |
         pip install -U codecov
         codecov

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKAGE = ecommerce_worker
-PYTHON_VERSION = py38
+PYTHON_VERSION_VAR=$(if $(PYTHON_VERSION),$(PYTHON_VERSION),py312)
 
 help: ## display this help message
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -15,7 +15,7 @@ worker: ## start the Celery worker process
 	celery -A ecommerce_worker worker --app=$(PACKAGE).celery_app:app --loglevel=info --queue=fulfillment,email_marketing
 
 test: requirements_tox  ## run unit tests and report on coverage
-	tox -e ${PYTHON_VERSION}
+	tox -e ${PYTHON_VERSION_VAR}
 
 quality: requirements_tox  ## run pep8 and pylint
 	tox -e quality

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PACKAGE = ecommerce_worker
-PYTHON_VERSION_VAR=$(if $(PYTHON_VERSION),$(PYTHON_VERSION),py312)
+PYTHON_VERSION_VAR=$(if $(PYTHON_VERSION),$(PYTHON_VERSION),3.12)
+PYTHON_ENV_VAR=$(if $(PYTHON_ENV),$(PYTHON_ENV),py312)
 
 help: ## display this help message
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -15,7 +16,7 @@ worker: ## start the Celery worker process
 	celery -A ecommerce_worker worker --app=$(PACKAGE).celery_app:app --loglevel=info --queue=fulfillment,email_marketing
 
 test: requirements_tox  ## run unit tests and report on coverage
-	tox -e ${PYTHON_VERSION_VAR}
+	python${PYTHON_VERSION_VAR} -m tox -e ${PYTHON_ENV_VAR}
 
 quality: requirements_tox  ## run pep8 and pylint
 	tox -e quality

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38},quality
+envlist = py{38, 311, 312},quality
 skipsdist = true
 
 [isort]


### PR DESCRIPTION
**Changes**

- Added CI checks as part of the [upgrade process](https://github.com/openedx/ecommerce-worker/issues/262) to python 3.11 and python 3.12.
- Also fixes one part of the [downstream issue](https://github.com/overhangio/tutor-ecommerce/issues/78) in tutor-ecommerce.
- Updated `docker-compose` to `docker compose`.
- Added a check on code coverage to only run for python 3.8 as we don't need to unnecessarily run it for every python verrsion.

# ⛔️ MAIN BRANCH WARNING! 2U EMPLOYEES must make branches against the 2u/main BRANCH

- [x] I have checked the branch to which I would like to merge.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

## If you're merging to master (not 2u/main) branch...

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production
    - `test.in` for test requirements
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] [Version](https://github.com/openedx/ecommerce-worker/blob/master/setup.py) bumped

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/ecommerce-worker/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub CI](https://github.com/openedx/ecommerce-worker/actions?query=workflow%3A%22Python+CI%22), verify version has been pushed to [PyPI](https://pypi.org/project/edx-ecommerce-worker/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [ecommerce](https://github.com/openedx/ecommerce) to upgrade dependencies (including ecommerce-worker)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in ecommerce will look for the latest version in PyPi.
    - Note: the ecommerce-worker constraint in ecommerce **must** also be bumped to the latest version in PyPi.
- [ ] Deploy `ecommerce`
- [ ] Deploy `ecomworker`