### PR TITLE
fix!: celery settings for ecommerce-worker

### DIFF
--- a/ecommerce_worker/configuration/base.py
+++ b/ecommerce_worker/configuration/base.py
@@ -34,8 +34,8 @@ CELERY_DEFAULT_QUEUE = DEFAULT_PRIORITY_QUEUE
 CELERYD_HIJACK_ROOT_LOGGER = False
 
 # Specify allowed serializers that are consistent with Celery 3 defaults
-CELERY_TASK_SERIALIZER = 'pickle'
-CELERY_RESULT_SERIALIZER = 'pickle'
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_RESULT_SERIALIZER = 'json'
 CELERY_EVENT_SERIALIZER = 'json'
 CELERY_ACCEPT_CONTENT = ['json', 'pickle', 'yaml']
 # END CELERY

--- a/ecommerce_worker/configuration/base.py
+++ b/ecommerce_worker/configuration/base.py
@@ -33,7 +33,7 @@ CELERY_DEFAULT_QUEUE = DEFAULT_PRIORITY_QUEUE
 # See http://celery.readthedocs.org/en/4.0/userguide/configuration.html#std:setting-worker_hijack_root_logger.
 CELERYD_HIJACK_ROOT_LOGGER = False
 
-# Specify allowed serializers that are consistent with Celery 3 defaults
+# Sync settings with LMS/CMS
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_EVENT_SERIALIZER = 'json'


### PR DESCRIPTION
Creating this PR to Sync ecommerce-worker celery related settings with LMS and CMS. 
Celery settings in ecommerce worker is causing below error in cms-worker. 
This error can be reproduced by
1. creating some unpublished content in CMS's course outline section
2. disable the ecommerce plugin and then run tutor local start -d
3. enable the ecommerce plugin and then run tutor local start -d
4. Below error can be seen in cms-worker container's logs

```
2024-05-16 19:08:35 [2024-05-16 14:08:35,099: CRITICAL/MainProcess] Can't decode message body: ContentDisallowed('Refusing to deserialize untrusted content of type pickle (application/x-python-serialize)') [type:'application/x-python-serialize' encoding:'binary' headers:{'clock': 1, 'expires': 1715868516.096079}] 2024-05-16 19:08:35
2024-05-16 19:08:35 body: b'\x80\x04\x95\x0e\x01\x00\x00\x00\x00\x00\x00}\x94(\x8c\x06method\x94\x8c\x05hello\x94\x8c\targuments\x94}\x94(\x8c\tfrom_node\x94\x8c\x13celery@71b2eeb6ff70\x94\x8c\x07revoked\x94}\x94u\x8c\x0bdestination\x94N\x8c\x07pattern\x94N\x8c\x07matcher\x94N\x8c\x06ticket\x94\x8c$3ffc6757-02d4-4ef1-8926-4e3dff9ed7a6\x94\x8c\x08reply_to\x94}\x94(\x8c\x08exchange\x94\x8c\x13reply.celery.pidbox\x94\x8c\x0brouting_key\x94\x8c$9a4e6cd3-05c1-33bb-a9ba-66c444c4ee0a\x94uu.' (281b) 2024-05-16 19:08:35 Traceback (most recent call last):
2024-05-16 19:08:35   File "/openedx/venv/lib/python3.11/site-packages/kombu/messaging.py", line 650, in _receive_callback
2024-05-16 19:08:35     decoded = None if on_m else message.decode()
2024-05-16 19:08:35                                 ^^^^^^^^^^^^^^^^
2024-05-16 19:08:35   File "/openedx/venv/lib/python3.11/site-packages/kombu/message.py", line 201, in decode
2024-05-16 19:08:35     self._decoded_cache = self._decode()
2024-05-16 19:08:35                           ^^^^^^^^^^^^^^
2024-05-16 19:08:35   File "/openedx/venv/lib/python3.11/site-packages/kombu/message.py", line 205, in _decode
2024-05-16 19:08:35     return loads(self.body, self.content_type,
2024-05-16 19:08:35            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-05-16 19:08:35   File "/openedx/venv/lib/python3.11/site-packages/kombu/serialization.py", line 255, in loads
2024-05-16 19:08:35     raise self._for_untrusted_content(content_type, 'untrusted')
2024-05-16 19:08:35 kombu.exceptions.ContentDisallowed: Refusing to deserialize untrusted content of type pickle (application/x-python-serialize)

```